### PR TITLE
Documentation small fix

### DIFF
--- a/documentation/index.yaml
+++ b/documentation/index.yaml
@@ -10,24 +10,38 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.html
 x-tagGroups:
   - name: Quickstart
+    tags: 
+      - ethers-ext
+      - web3js-ext
+      - web3j-ext
+      - web3py-ext
   - name: Web3rpc
     tags:
       - eth
       - klay
       - txpool
+      - governance
       - net
+      - admin
       - personal
       - debug
-      - governance
       - mainbridge
       - subbridge
-      - RewardSpec
-      - admin
   - name: Accounts
+    tags: 
+      - account
   - name: Transactions
+    tags:
+      - legacy
   - name: Smart Contracts
+    tags:
+      - deploy
   - name: Advanced
+    tags:
+      - web3py middleware
   - name: Usecases
+    tags:
+      - role-based
 servers:
   - url: http://localhost:7151
   - url: https://api.baobab.klaytn.net:8651

--- a/documentation/site/README.md
+++ b/documentation/site/README.md
@@ -1,9 +1,4 @@
 ## site
-
-- klaytn-openapi.yaml
-    - Define OpenAPIs created with `yarn build` using [redocly](https://www.notion.so/User-Guide-for-klaytn-Open-SDK-00525b67fc234d0ba571550e05d1c472)
-    - Create divided API files as one Yaml file
-    - This document is used as a specification in redocly format API document and SwaggerUI
 - index.html
     - API documentation in redocly format is provided based on klaytn-openapi.yaml
     - By providing Request samples, you can see examples of the development language you want.


### PR DESCRIPTION
- klaytn-openapi.yaml contents was deleted in  documentation/site/README.md
- changed the tag group names