### PR TITLE
Update package.json in JavaScript openapi-test

### DIFF
--- a/web3rpc/sdk/client/javascript/openapi-test/package.json
+++ b/web3rpc/sdk/client/javascript/openapi-test/package.json
@@ -6,7 +6,8 @@
     "test": "jest --silent=false"
   },
   "dependencies": {
-    "web3": "^1.9.0"
+    "web3": "^1.9.0",
+    "opensdk-javascript": "latest"
   },
   "devDependencies": {
     "@babel/core": "^7.20.7",


### PR DESCRIPTION
Without this dependency, test will fail like below. 

FAIL  test
  ● Test suite failed to run
    Cannot find module 'opensdk-javascript' from '*Api.test.js'

    > 1 | const OpenSDK = require("opensdk-javascript");
          |                 ^
      2 | const { expect } = require("@jest/globals");
      3 |
      4 | const sdk = new OpenSDK(new OpenSDK.ApiClient("https://api.baobab.klaytn.net:8651"));