### PR TITLE
Refactor documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,7 +111,7 @@ bin/**.jar
 **/coverage
 
 # OpenAPI generated
-**/web3klaytn.yaml
+**/web3rpc.yaml
 
 .DS_Store
 

--- a/documentation/generate-docs.sh
+++ b/documentation/generate-docs.sh
@@ -1,2 +1,2 @@
-yarn build index@v1.0.0 -o ./web3klaytn.yaml
+yarn build index@v1.0.0 -o ./web3rpc.yaml
 yarn remove_query_param

--- a/documentation/index.yaml
+++ b/documentation/index.yaml
@@ -27,9 +27,6 @@ servers:
   - url: https://public-en-cypress.klaytn.net
 paths:
 
-
-
-
   # klay/account
   /klay/account/accountCreated:
     $ref: ../web3rpc/rpc-specs/paths/klay/account/accountCreated.yaml#/paths/~1klay~1accountCreated

--- a/documentation/index.yaml
+++ b/documentation/index.yaml
@@ -1,6 +1,6 @@
 openapi: "3.0.2"
 info:
-  title: web3klaytn
+  title: web3rpc
   version: "0.9.0"
   contact:
     name: API support
@@ -9,13 +9,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
 x-tagGroups:
-  - name: Quickstart
-    tags: 
-      - ethers-ext
-      - web3js-ext
-      - web3j-ext
-      - web3py-ext
-  - name: Web3rpc
+  - name: namespaces
     tags:
       - eth
       - klay
@@ -27,26 +21,15 @@ x-tagGroups:
       - debug
       - mainbridge
       - subbridge
-  - name: Accounts
-    tags: 
-      - account
-  - name: Transactions
-    tags:
-      - legacy
-  - name: Smart Contracts
-    tags:
-      - deploy
-  - name: Advanced
-    tags:
-      - web3py middleware
-  - name: Usecases
-    tags:
-      - role-based
 servers:
-  - url: http://localhost:7151
+  - url: http://localhost:8551
   - url: https://api.baobab.klaytn.net:8651
   - url: https://public-en-cypress.klaytn.net
 paths:
+
+
+
+
   # klay/account
   /klay/account/accountCreated:
     $ref: ../web3rpc/rpc-specs/paths/klay/account/accountCreated.yaml#/paths/~1klay~1accountCreated
@@ -54,34 +37,42 @@ paths:
     $ref: ../web3rpc/rpc-specs/paths/klay/account/accounts.yaml#/paths/~1klay~1accounts
   /klay/account/decodeAccountKey:
     $ref: ../web3rpc/rpc-specs/paths/klay/account/decodeAccountKey.yaml#/paths/~1klay~1decodeAccountKey
-  /klay/account/getAccountKey:
-    $ref: ../web3rpc/rpc-specs/paths/klay/account/getAccountKey.yaml#/paths/~1klay~1getAccountKey
-  /klay/account/getCode:
-    $ref: ../web3rpc/rpc-specs/paths/klay/account/getCode.yaml#/paths/~1klay~1getCode
   /klay/account/encodeAccountKey:
     $ref: ../web3rpc/rpc-specs/paths/klay/account/encodeAccountKey.yaml#/paths/~1klay~1encodeAccountKey
   /klay/account/getAccount:
     $ref: ../web3rpc/rpc-specs/paths/klay/account/getAccount.yaml#/paths/~1klay~1getAccount
+  /klay/account/getAccountKey:
+    $ref: ../web3rpc/rpc-specs/paths/klay/account/getAccountKey.yaml#/paths/~1klay~1getAccountKey
   /klay/account/getBalance:
     $ref: ../web3rpc/rpc-specs/paths/klay/account/getBalance.yaml#/paths/~1klay~1getBalance
-  /klay/account/sign:
-    $ref: ../web3rpc/rpc-specs/paths/klay/account/sign.yaml#/paths/~1klay~1sign
+  /klay/account/getCode:
+    $ref: ../web3rpc/rpc-specs/paths/klay/account/getCode.yaml#/paths/~1klay~1getCode
   /klay/account/getTransactionCount:
     $ref: ../web3rpc/rpc-specs/paths/klay/account/getTransactionCount.yaml#/paths/~1klay~1getTransactionCount
   /klay/account/isContractAccount:
     $ref: ../web3rpc/rpc-specs/paths/klay/account/isContractAccount.yaml#/paths/~1klay~1isContractAccount
+  /klay/account/sign:
+    $ref: ../web3rpc/rpc-specs/paths/klay/account/sign.yaml#/paths/~1klay~1sign
 
   # klay/block
   /klay/block/blockNumber:
     $ref: ../web3rpc/rpc-specs/paths/klay/block/blockNumber.yaml#/paths/~1klay~1blockNumber
   /klay/block/getBlockByHash:
     $ref: ../web3rpc/rpc-specs/paths/klay/block/getBlockByHash.yaml#/paths/~1klay~1getBlockByHash
+  /klay/block/getBlockByNumber:
+    $ref: ../web3rpc/rpc-specs/paths/klay/block/getBlockByNumber.yaml#/paths/~1klay~1getBlockByNumber
   /klay/block/getBlockReceipts:
     $ref: ../web3rpc/rpc-specs/paths/klay/block/getBlockReceipts.yaml#/paths/~1klay~1getBlockReceipts
+  /klay/block/getBlockTransactionCountByHash:
+    $ref: ../web3rpc/rpc-specs/paths/klay/block/getBlockTransactionCountByHash.yaml#/paths/~1klay~1getBlockTransactionCountByHash
   /klay/block/getBlockTransactionCountByNumber:
     $ref: ../web3rpc/rpc-specs/paths/klay/block/getBlockTransactionCountByNumber.yaml#/paths/~1klay~1getBlockTransactionCountByNumber
+  /klay/block/getBlockWithConsensusInfoByHash:
+    $ref: ../web3rpc/rpc-specs/paths/klay/block/getBlockWithConsensusInfoByHash.yaml#/paths/~1klay~1getBlockWithConsensusInfoByHash
   /klay/block/getBlockWithConsensusInfoByNumber:
     $ref: ../web3rpc/rpc-specs/paths/klay/block/getBlockWithConsensusInfoByNumber.yaml#/paths/~1klay~1getBlockWithConsensusInfoByNumber
+  /klay/block/getBlockWithConsensusInfoByNumberRange:
+    $ref: ../web3rpc/rpc-specs/paths/klay/block/getBlockWithConsensusInfoByNumberRange.yaml#/paths/~1klay~1getBlockWithConsensusInfoByNumberRange
   /klay/block/getCommittee:
     $ref: ../web3rpc/rpc-specs/paths/klay/block/getCommittee.yaml#/paths/~1klay~1getCommittee
   /klay/block/getCommitteeSize:
@@ -90,48 +81,52 @@ paths:
     $ref: ../web3rpc/rpc-specs/paths/klay/block/getCouncil.yaml#/paths/~1klay~1getCouncil
   /klay/block/getCouncilSize:
     $ref: ../web3rpc/rpc-specs/paths/klay/block/getCouncilSize.yaml#/paths/~1klay~1getCouncilSize
-  /klay/block/getBlockByNumber:
-    $ref: ../web3rpc/rpc-specs/paths/klay/block/getBlockByNumber.yaml#/paths/~1klay~1getBlockByNumber
-  /klay/block/getBlockTransactionCountByHash:
-    $ref: ../web3rpc/rpc-specs/paths/klay/block/getBlockTransactionCountByHash.yaml#/paths/~1klay~1getBlockTransactionCountByHash
-  /klay/block/getHeaderByNumber:
-    $ref: ../web3rpc/rpc-specs/paths/klay/block/getHeaderByNumber.yaml#/paths/~1klay~1getHeaderByNumber
   /klay/block/getHeaderByHash:
     $ref: ../web3rpc/rpc-specs/paths/klay/block/getHeaderByHash.yaml#/paths/~1klay~1getHeaderByHash
+  /klay/block/getHeaderByNumber:
+    $ref: ../web3rpc/rpc-specs/paths/klay/block/getHeaderByNumber.yaml#/paths/~1klay~1getHeaderByNumber
   /klay/block/getRewards:
     $ref: ../web3rpc/rpc-specs/paths/klay/block/getRewards.yaml#/paths/~1klay~1getRewards
   /klay/block/getStorageAt:
     $ref: ../web3rpc/rpc-specs/paths/klay/block/getStorageAt.yaml#/paths/~1klay~1getStorageAt
   /klay/block/syncing:
     $ref: ../web3rpc/rpc-specs/paths/klay/block/syncing.yaml#/paths/~1klay~1syncing
-  /klay/block/getBlockWithConsensusInfoByNumberRange:
-    $ref: ../web3rpc/rpc-specs/paths/klay/block/getBlockWithConsensusInfoByNumberRange.yaml#/paths/~1klay~1getBlockWithConsensusInfoByNumberRange
-  /klay/block/getBlockWithConsensusInfoByHash:
-    $ref: ../web3rpc/rpc-specs/paths/klay/block/getBlockWithConsensusInfoByHash.yaml#/paths/~1klay~1getBlockWithConsensusInfoByHash
 
   # klay/transaction
+  /klay/createAccessList:
+    $ref: ../web3rpc/rpc-specs/paths/klay/transaction/createAccessList.yaml#/paths/~1klay~1createAccessList
+  /klay/getRawTransactionByBlockHashAndIndex:
+    $ref: ../web3rpc/rpc-specs/paths/klay/transaction/getRawTransactionByBlockHashAndIndex.yaml#/paths/~1klay~1getRawTransactionByBlockHashAndIndex
+  /klay/getRawTransactionByBlockNumberAndIndex:
+    $ref: ../web3rpc/rpc-specs/paths/klay/transaction/getRawTransactionByBlockNumberAndIndex.yaml#/paths/~1klay~1getRawTransactionByBlockNumberAndIndex
+  /klay/getRawTransactionByHash:
+    $ref: ../web3rpc/rpc-specs/paths/klay/transaction/getRawTransactionByHash.yaml#/paths/~1klay~1getRawTransactionByHash
+  /klay/resend:
+    $ref: ../web3rpc/rpc-specs/paths/klay/transaction/resend.yaml#/paths/~1klay~1resend
   /klay/transaction/call:
     $ref: ../web3rpc/rpc-specs/paths/klay/transaction/call.yaml#/paths/~1klay~1call
-  /klay/transaction/getDecodedAnchoringTransactionByHash:
-    $ref: ../web3rpc/rpc-specs/paths/klay/transaction/getDecodedAnchoringTransactionByHash.yaml#/paths/~1klay~1getDecodedAnchoringTransactionByHash
-  /klay/transaction/estimateGas:
-    $ref: ../web3rpc/rpc-specs/paths/klay/transaction/estimateGas.yaml#/paths/~1klay~1estimateGas
-  /klay/transaction/getTransactionByBlockNumberAndIndex:
-    $ref: ../web3rpc/rpc-specs/paths/klay/transaction/getTransactionByBlockNumberAndIndex.yaml#/paths/~1klay~1getTransactionByBlockNumberAndIndex
-  /klay/transaction/getTransactionBySenderTxHash:
-    $ref: ../web3rpc/rpc-specs/paths/klay/transaction/getTransactionBySenderTxHash.yaml#/paths/~1klay~1getTransactionBySenderTxHash
-  /klay/transaction/getTransactionByBlockHashAndIndex:
-    $ref: ../web3rpc/rpc-specs/paths/klay/transaction/getTransactionByBlockHashAndIndex.yaml#/paths/~1klay~1getTransactionByBlockHashAndIndex
-  /klay/transaction/getTransactionByHash:
-    $ref: ../web3rpc/rpc-specs/paths/klay/transaction/getTransactionByHash.yaml#/paths/~1klay~1getTransactionByHash
-  /klay/transaction/getTransactionReceipt:
-    $ref: ../web3rpc/rpc-specs/paths/klay/transaction/getTransactionReceipt.yaml#/paths/~1klay~1getTransactionReceipt
-  /klay/transaction/sendRawTransaction:
-    $ref: ../web3rpc/rpc-specs/paths/klay/transaction/sendRawTransaction.yaml#/paths/~1klay~1sendRawTransaction
   /klay/transaction/estimateComputationCost:
     $ref: ../web3rpc/rpc-specs/paths/klay/transaction/estimateComputationCost.yaml#/paths/~1klay~1estimateComputationCost
+  /klay/transaction/estimateGas:
+    $ref: ../web3rpc/rpc-specs/paths/klay/transaction/estimateGas.yaml#/paths/~1klay~1estimateGas
+  /klay/transaction/getDecodedAnchoringTransactionByHash:
+    $ref: ../web3rpc/rpc-specs/paths/klay/transaction/getDecodedAnchoringTransactionByHash.yaml#/paths/~1klay~1getDecodedAnchoringTransactionByHash
+  /klay/transaction/getTransactionByBlockHashAndIndex:
+    $ref: ../web3rpc/rpc-specs/paths/klay/transaction/getTransactionByBlockHashAndIndex.yaml#/paths/~1klay~1getTransactionByBlockHashAndIndex
+  /klay/transaction/getTransactionByBlockNumberAndIndex:
+    $ref: ../web3rpc/rpc-specs/paths/klay/transaction/getTransactionByBlockNumberAndIndex.yaml#/paths/~1klay~1getTransactionByBlockNumberAndIndex
+  /klay/transaction/getTransactionByHash:
+    $ref: ../web3rpc/rpc-specs/paths/klay/transaction/getTransactionByHash.yaml#/paths/~1klay~1getTransactionByHash
+  /klay/transaction/getTransactionBySenderTxHash:
+    $ref: ../web3rpc/rpc-specs/paths/klay/transaction/getTransactionBySenderTxHash.yaml#/paths/~1klay~1getTransactionBySenderTxHash
+  /klay/transaction/getTransactionReceipt:
+    $ref: ../web3rpc/rpc-specs/paths/klay/transaction/getTransactionReceipt.yaml#/paths/~1klay~1getTransactionReceipt
   /klay/transaction/getTransactionReceiptBySenderTxHash:
     $ref: ../web3rpc/rpc-specs/paths/klay/transaction/getTransactionReceiptBySenderTxHash.yaml#/paths/~1klay~1getTransactionReceiptBySenderTxHash
+  /klay/transaction/pendingTransactions:
+    $ref: ../web3rpc/rpc-specs/paths/klay/transaction/pendingTransactions.yaml#/paths/~1klay~1pendingTransactions
+  /klay/transaction/sendRawTransaction:
+    $ref: ../web3rpc/rpc-specs/paths/klay/transaction/sendRawTransaction.yaml#/paths/~1klay~1sendRawTransaction
   /klay/transaction/sendTransaction:
     $ref: ../web3rpc/rpc-specs/paths/klay/transaction/sendTransaction.yaml#/paths/~1klay~1sendTransaction
   /klay/transaction/sendTransactionAsFeePayer:
@@ -140,18 +135,18 @@ paths:
     $ref: ../web3rpc/rpc-specs/paths/klay/transaction/signTransaction.yaml#/paths/~1klay~1signTransaction
   /klay/transaction/signTransactionAsFeePayer:
     $ref: ../web3rpc/rpc-specs/paths/klay/transaction/signTransactionAsFeePayer.yaml#/paths/~1klay~1signTransactionAsFeePayer
-  /klay/transaction/pendingTransactions:
-    $ref: ../web3rpc/rpc-specs/paths/klay/transaction/pendingTransactions.yaml#/paths/~1klay~1pendingTransactions
 
   # klay/configuration
   /klay/configuration/chainID:
     $ref: ../web3rpc/rpc-specs/paths/klay/configuration/chainID.yaml#/paths/~1klay~1chainID
   /klay/configuration/clientVersion:
     $ref: ../web3rpc/rpc-specs/paths/klay/configuration/clientVersion.yaml#/paths/~1klay~1clientVersion
-  /klay/configuration/gasPriceAt:
-    $ref: ../web3rpc/rpc-specs/paths/klay/configuration/gasPriceAt.yaml#/paths/~1klay~1gasPriceAt
   /klay/configuration/gasPrice:
     $ref: ../web3rpc/rpc-specs/paths/klay/configuration/gasPrice.yaml#/paths/~1klay~1gasPrice
+  /klay/configuration/gasPriceAt:
+    $ref: ../web3rpc/rpc-specs/paths/klay/configuration/gasPriceAt.yaml#/paths/~1klay~1gasPriceAt
+  /klay/configuration/getChainConfig:
+    $ref: ../web3rpc/rpc-specs/paths/klay/configuration/getChainConfig.yaml#/paths/~1klay~1getChainConfig
   /klay/configuration/isParallelDBWrite:
     $ref: ../web3rpc/rpc-specs/paths/klay/configuration/isParallelDBWrite.yaml#/paths/~1klay~1isParallelDBWrite
   /klay/configuration/isSenderTxHashIndexingEnabled:
@@ -160,58 +155,44 @@ paths:
     $ref: ../web3rpc/rpc-specs/paths/klay/configuration/protocolVersion.yaml#/paths/~1klay~1protocolVersion
   /klay/configuration/rewardbase:
     $ref: ../web3rpc/rpc-specs/paths/klay/configuration/rewardBase.yaml#/paths/~1klay~1rewardbase
-  /klay/configuration/getChainConfig:
-    $ref: ../web3rpc/rpc-specs/paths/klay/configuration/getChainConfig.yaml#/paths/~1klay~1getChainConfig
 
   # klay/filter
   /klay/filter/getFilterChanges:
     $ref: ../web3rpc/rpc-specs/paths/klay/filter/getFilterChanges.yaml#/paths/~1klay~1getFilterChanges
   /klay/filter/getFilterLogs:
     $ref: ../web3rpc/rpc-specs/paths/klay/filter/getFilterLogs.yaml#/paths/~1klay~1getFilterLogs
-  /klay/filter/newBlockFilter:
-    $ref: ../web3rpc/rpc-specs/paths/klay/filter/newBlockFilter.yaml#/paths/~1klay~1newBlockFilter
-  /klay/filter/newPendingTransactionFilter:
-    $ref: ../web3rpc/rpc-specs/paths/klay/filter/newPendingTransactionFilter.yaml#/paths/~1klay~1newPendingTransactionFilter
-  /klay/filter/newFilter:
-    $ref: ../web3rpc/rpc-specs/paths/klay/filter/newFilter.yaml#/paths/~1klay~1newFilter
-  /klay/filter/uninstallFilter:
-    $ref: ../web3rpc/rpc-specs/paths/klay/filter/uninstallFilter.yaml#/paths/~1klay~1uninstallFilter
-  # /klay/filter/unsubscribe:
-  #   $ref: ../web3rpc/rpc-specs/paths/klay/filter/unsubscribe.yaml#/paths/~1klay~1unsubscribe
   /klay/filter/getLogs:
     $ref: ../web3rpc/rpc-specs/paths/klay/filter/getLogs.yaml#/paths/~1klay~1getLogs
-  # /klay/filter/subscribe:
-  #   $ref: ../web3rpc/rpc-specs/paths/klay/filter/subscribe.yaml#/paths/~1klay~1subscribe
+  /klay/filter/newBlockFilter:
+    $ref: ../web3rpc/rpc-specs/paths/klay/filter/newBlockFilter.yaml#/paths/~1klay~1newBlockFilter
+  /klay/filter/newFilter:
+    $ref: ../web3rpc/rpc-specs/paths/klay/filter/newFilter.yaml#/paths/~1klay~1newFilter
+  /klay/filter/newPendingTransactionFilter:
+    $ref: ../web3rpc/rpc-specs/paths/klay/filter/newPendingTransactionFilter.yaml#/paths/~1klay~1newPendingTransactionFilter
+  /klay/filter/subscribe:
+    $ref: ../web3rpc/rpc-specs/paths/klay/filter/subscribe.yaml#/paths/~1klay~1subscribe
+  /klay/filter/uninstallFilter:
+    $ref: ../web3rpc/rpc-specs/paths/klay/filter/uninstallFilter.yaml#/paths/~1klay~1uninstallFilter
+  /klay/filter/unsubscribe:
+    $ref: ../web3rpc/rpc-specs/paths/klay/filter/unsubscribe.yaml#/paths/~1klay~1unsubscribe
 
   # klay/gas
   /klay/gas/feeHistory:
     $ref: ../web3rpc/rpc-specs/paths/klay/gas/feeHistory.yaml#/paths/~1klay~1feeHistory
   /klay/gas/lowerBoundGasPrice:
     $ref: ../web3rpc/rpc-specs/paths/klay/gas/lowerBoundGasPrice.yaml#/paths/~1klay~1lowerBoundGasPrice
-  /klay/gas/upperBoundGasPrice:
-    $ref: ../web3rpc/rpc-specs/paths/klay/gas/upperBoundGasPrice.yaml#/paths/~1klay~1upperBoundGasPrice
   /klay/gas/maxPriorityFeePerGas:
     $ref: ../web3rpc/rpc-specs/paths/klay/gas/maxPriorityFeePerGas.yaml#/paths/~1klay~1maxPriorityFeePerGas
+  /klay/gas/upperBoundGasPrice:
+    $ref: ../web3rpc/rpc-specs/paths/klay/gas/upperBoundGasPrice.yaml#/paths/~1klay~1upperBoundGasPrice
 
   # klay/miscellaneous
+  /klay/getStakingInfo:
+    $ref: ../web3rpc/rpc-specs/paths/klay/miscellaneous/getStakingInfo.yaml#/paths/~1klay~1getStakingInfo
   /klay/miscellaneous/sha3:
     $ref: ../web3rpc/rpc-specs/paths/klay/miscellaneous/sha3.yaml#/paths/~1klay~1sha3
-
-  # klay/others
-  /klay/createAccessList:
-    $ref: ../web3rpc/rpc-specs/paths/klay/others/createAccessList.yaml#/paths/~1klay~1createAccessList
-  /klay/getRawTransactionByBlockHashAndIndex:
-    $ref: ../web3rpc/rpc-specs/paths/klay/others/getRawTransactionByBlockHashAndIndex.yaml#/paths/~1klay~1getRawTransactionByBlockHashAndIndex
-  /klay/getRawTransactionByHash:
-    $ref: ../web3rpc/rpc-specs/paths/klay/others/getRawTransactionByHash.yaml#/paths/~1klay~1getRawTransactionByHash
   /klay/nodeAddress:
-    $ref: ../web3rpc/rpc-specs/paths/klay/others/nodeAddress.yaml#/paths/~1klay~1nodeAddress
-  /klay/resend:
-    $ref: ../web3rpc/rpc-specs/paths/klay/others/resend.yaml#/paths/~1klay~1resend
-  /klay/getRawTransactionByBlockNumberAndIndex:
-    $ref: ../web3rpc/rpc-specs/paths/klay/others/getRawTransactionByBlockNumberAndIndex.yaml#/paths/~1klay~1getRawTransactionByBlockNumberAndIndex
-  /klay/getStakingInfo:
-    $ref: ../web3rpc/rpc-specs/paths/klay/others/getStakingInfo.yaml#/paths/~1klay~1getStakingInfo
+    $ref: ../web3rpc/rpc-specs/paths/klay/miscellaneous/nodeAddress.yaml#/paths/~1klay~1nodeAddress
 
   # eth/account
   /eth/account/accounts:
@@ -220,10 +201,10 @@ paths:
     $ref: ../web3rpc/rpc-specs/paths/eth/account/getBalance.yaml#/paths/~1eth~1getBalance
   /eth/account/getCode:
     $ref: ../web3rpc/rpc-specs/paths/eth/account/getCode.yaml#/paths/~1eth~1getCode
-  /eth/account/sign:
-    $ref: ../web3rpc/rpc-specs/paths/eth/account/sign.yaml#/paths/~1eth~1sign
   /eth/account/getTransactionCount:
     $ref: ../web3rpc/rpc-specs/paths/eth/account/getTransactionCount.yaml#/paths/~1eth~1getTransactionCount
+  /eth/account/sign:
+    $ref: ../web3rpc/rpc-specs/paths/eth/account/sign.yaml#/paths/~1eth~1sign
 
   # eth/block
   /eth/block/blockNumber:
@@ -234,30 +215,44 @@ paths:
     $ref: ../web3rpc/rpc-specs/paths/eth/block/getBlockByNumber.yaml#/paths/~1eth~1getBlockByNumber
   /eth/block/getBlockTransactionCountByHash:
     $ref: ../web3rpc/rpc-specs/paths/eth/block/getBlockTransactionCountByHash.yaml#/paths/~1eth~1getBlockTransactionCountByHash
-  /eth/block/getHeaderByNumber:
-    $ref: ../web3rpc/rpc-specs/paths/eth/block/getHeaderByNumber.yaml#/paths/~1eth~1getHeaderByNumber
+  /eth/block/getBlockTransactionCountByNumber:
+    $ref: ../web3rpc/rpc-specs/paths/eth/block/getBlockTransactionCountByNumber.yaml#/paths/~1eth~1getBlockTransactionCountByNumber
   /eth/block/getHeaderByHash:
     $ref: ../web3rpc/rpc-specs/paths/eth/block/getHeaderByHash.yaml#/paths/~1eth~1getHeaderByHash
+  /eth/block/getHeaderByNumber:
+    $ref: ../web3rpc/rpc-specs/paths/eth/block/getHeaderByNumber.yaml#/paths/~1eth~1getHeaderByNumber
   /eth/block/getStorageAt:
     $ref: ../web3rpc/rpc-specs/paths/eth/block/getStorageAt.yaml#/paths/~1eth~1getStorageAt
-  /eth/block/getUncleCountByBlockHash:
-    $ref: ../web3rpc/rpc-specs/paths/eth/block/getUncleCountByBlockHash.yaml#/paths/~1eth~1getUncleCountByBlockHash
   /eth/block/getUncleByBlockHashAndIndex:
     $ref: ../web3rpc/rpc-specs/paths/eth/block/getUncleByBlockHashAndIndex.yaml#/paths/~1eth~1getUncleByBlockHashAndIndex
   /eth/block/getUncleByBlockNumberAndIndex:
     $ref: ../web3rpc/rpc-specs/paths/eth/block/getUncleByBlockNumberAndIndex.yaml#/paths/~1eth~1getUncleByBlockNumberAndIndex
+  /eth/block/getUncleCountByBlockHash:
+    $ref: ../web3rpc/rpc-specs/paths/eth/block/getUncleCountByBlockHash.yaml#/paths/~1eth~1getUncleCountByBlockHash
   /eth/block/getUncleCountByBlockNumber:
     $ref: ../web3rpc/rpc-specs/paths/eth/block/getUncleCountByBlockNumber.yaml#/paths/~1eth~1getUncleCountByBlockNumber
-  /eth/block/syncing:
-    $ref: ../web3rpc/rpc-specs/paths/eth/block/syncing.yaml#/paths/~1eth~1syncing
   /eth/block/mining:
     $ref: ../web3rpc/rpc-specs/paths/eth/block/mining.yaml#/paths/~1eth~1mining
-  /eth/block/getBlockTransactionCountByNumber:
-    $ref: ../web3rpc/rpc-specs/paths/eth/block/getBlockTransactionCountByNumber.yaml#/paths/~1eth~1getBlockTransactionCountByNumber
+  /eth/block/syncing:
+    $ref: ../web3rpc/rpc-specs/paths/eth/block/syncing.yaml#/paths/~1eth~1syncing
 
   # eth/transaction
+  /eth/createAccessList:
+    $ref: ../web3rpc/rpc-specs/paths/eth/transaction/createAccessList.yaml#/paths/~1eth~1createAccessList
+  /eth/getRawTransactionByBlockHashAndIndex:
+    $ref: ../web3rpc/rpc-specs/paths/eth/transaction/getRawTransactionByBlockHashAndIndex.yaml#/paths/~1eth~1getRawTransactionByBlockHashAndIndex
+  /eth/getRawTransactionByBlockNumberAndIndex:
+    $ref: ../web3rpc/rpc-specs/paths/eth/transaction/getRawTransactionByBlockNumberAndIndex.yaml#/paths/~1eth~1getRawTransactionByBlockNumberAndIndex
+  /eth/getRawTransactionByHash:
+    $ref: ../web3rpc/rpc-specs/paths/eth/transaction/getRawTransactionByHash.yaml#/paths/~1eth~1getRawTransactionByHash
+  /eth/resend:
+    $ref: ../web3rpc/rpc-specs/paths/eth/transaction/resend.yaml#/paths/~1eth~1resend
   /eth/transaction/call:
     $ref: ../web3rpc/rpc-specs/paths/eth/transaction/call.yaml#/paths/~1eth~1call
+  /eth/transaction/estimateGas:
+    $ref: ../web3rpc/rpc-specs/paths/eth/transaction/estimateGas.yaml#/paths/~1eth~1estimateGas
+  /eth/transaction/fillTransaction:
+    $ref: ../web3rpc/rpc-specs/paths/eth/transaction/fillTransaction.yaml#/paths/~1eth~1fillTransaction
   /eth/transaction/getTransactionByBlockHashAndIndex:
     $ref: ../web3rpc/rpc-specs/paths/eth/transaction/getTransactionByBlockHashAndIndex.yaml#/paths/~1eth~1getTransactionByBlockHashAndIndex
   /eth/transaction/getTransactionByBlockNumberAndIndex:
@@ -266,28 +261,24 @@ paths:
     $ref: ../web3rpc/rpc-specs/paths/eth/transaction/getTransactionByHash.yaml#/paths/~1eth~1getTransactionByHash
   /eth/transaction/getTransactionReceipt:
     $ref: ../web3rpc/rpc-specs/paths/eth/transaction/getTransactionReceipt.yaml#/paths/~1eth~1getTransactionReceipt
+  /eth/transaction/pendingTransactions:
+    $ref: ../web3rpc/rpc-specs/paths/eth/transaction/pendingTransactions.yaml#/paths/~1eth~1pendingTransactions
   /eth/transaction/sendRawTransaction:
     $ref: ../web3rpc/rpc-specs/paths/eth/transaction/sendRawTransaction.yaml#/paths/~1eth~1sendRawTransaction
   /eth/transaction/sendTransaction:
     $ref: ../web3rpc/rpc-specs/paths/eth/transaction/sendTransaction.yaml#/paths/~1eth~1sendTransaction
   /eth/transaction/signTransaction:
     $ref: ../web3rpc/rpc-specs/paths/eth/transaction/signTransaction.yaml#/paths/~1eth~1signTransaction
-  /eth/transaction/pendingTransactions:
-    $ref: ../web3rpc/rpc-specs/paths/eth/transaction/pendingTransactions.yaml#/paths/~1eth~1pendingTransactions
-  /eth/transaction/fillTransaction:
-    $ref: ../web3rpc/rpc-specs/paths/eth/transaction/fillTransaction.yaml#/paths/~1eth~1fillTransaction
-  /eth/transaction/estimateGas:
-    $ref: ../web3rpc/rpc-specs/paths/eth/transaction/estimateGas.yaml#/paths/~1eth~1estimateGas
 
   # eth/config
   /eth/config/chainID:
     $ref: ../web3rpc/rpc-specs/paths/eth/config/chainId.yaml#/paths/~1eth~1chainId
-  /eth/config/gasPrice:
-    $ref: ../web3rpc/rpc-specs/paths/eth/config/gasPrice.yaml#/paths/~1eth~1gasPrice
   /eth/config/coinbase:
     $ref: ../web3rpc/rpc-specs/paths/eth/config/coinbase.yaml#/paths/~1eth~1coinbase
   /eth/config/etherbase:
     $ref: ../web3rpc/rpc-specs/paths/eth/config/etherbase.yaml#/paths/~1eth~1etherbase
+  /eth/config/gasPrice:
+    $ref: ../web3rpc/rpc-specs/paths/eth/config/gasPrice.yaml#/paths/~1eth~1gasPrice
   /eth/protocolVersion:
     $ref: ../web3rpc/rpc-specs/paths/eth/config/protocolVersion.yaml#/paths/~1eth~1protocolVersion
 
@@ -298,50 +289,38 @@ paths:
     $ref: ../web3rpc/rpc-specs/paths/eth/gas/maxPriorityFeePerGas.yaml#/paths/~1eth~1maxPriorityFeePerGas
 
   # eth/filter
-  /eth/filter/getFilterLogs:
-    $ref: ../web3rpc/rpc-specs/paths/eth/filter/getFilterLogs.yaml#/paths/~1eth~1getFilterLogs
   /eth/filter/getFilterChanges:
     $ref: ../web3rpc/rpc-specs/paths/eth/filter/getFilterChanges.yaml#/paths/~1eth~1getFilterChanges
-  /eth/filter/uninstallFilter:
-    $ref: ../web3rpc/rpc-specs/paths/eth/filter/uninstallFilter.yaml#/paths/~1eth~1uninstallFilter
+  /eth/filter/getFilterLogs:
+    $ref: ../web3rpc/rpc-specs/paths/eth/filter/getFilterLogs.yaml#/paths/~1eth~1getFilterLogs
+  /eth/filter/getLogs:
+    $ref: ../web3rpc/rpc-specs/paths/eth/filter/getLogs.yaml#/paths/~1eth~1getLogs
   /eth/filter/newBlockFilter:
     $ref: ../web3rpc/rpc-specs/paths/eth/filter/newBlockFilter.yaml#/paths/~1eth~1newBlockFilter
   /eth/filter/newFilter:
     $ref: ../web3rpc/rpc-specs/paths/eth/filter/newFilter.yaml#/paths/~1eth~1newFilter
   /eth/filter/newPendingTransactionFilter:
     $ref: ../web3rpc/rpc-specs/paths/eth/filter/newPendingTransactionFilter.yaml#/paths/~1eth~1newPendingTransactionFilter
-  /eth/filter/getLogs:
-    $ref: ../web3rpc/rpc-specs/paths/eth/filter/getLogs.yaml#/paths/~1eth~1getLogs
-  # /eth/filter/subscribe:
-  #   $ref: ../web3rpc/rpc-specs/paths/eth/filter/subscribe.yaml#/paths/~1eth~1subscribe
-  # /eth/filter/unsubscribe:
-  #   $ref: ../web3rpc/rpc-specs/paths/eth/filter/unsubscribe.yaml#/paths/~1eth~1unsubscribe
+  /eth/filter/subscribe:
+    $ref: ../web3rpc/rpc-specs/paths/eth/filter/subscribe.yaml#/paths/~1eth~1subscribe
+  /eth/filter/uninstallFilter:
+    $ref: ../web3rpc/rpc-specs/paths/eth/filter/uninstallFilter.yaml#/paths/~1eth~1uninstallFilter
+  /eth/filter/unsubscribe:
+    $ref: ../web3rpc/rpc-specs/paths/eth/filter/unsubscribe.yaml#/paths/~1eth~1unsubscribe
 
   # eth/miscellaneous:
-  /eth/miscellaneous/submitWork:
-    $ref: ../web3rpc/rpc-specs/paths/eth/miscellaneous/submitWork.yaml#/paths/~1eth~1submitWork
+  /eth/getProof:
+    $ref: ../web3rpc/rpc-specs/paths/eth/miscellaneous/getProof.yaml#/paths/~1eth~1getProof
+  /eth/miscellaneous/getHashrate:
+    $ref: ../web3rpc/rpc-specs/paths/eth/miscellaneous/getHashrate.yaml#/paths/~1eth~1getHashrate
+  /eth/miscellaneous/getWork:
+    $ref: ../web3rpc/rpc-specs/paths/eth/miscellaneous/getWork.yaml#/paths/~1eth~1getWork
   /eth/miscellaneous/hashrate:
     $ref: ../web3rpc/rpc-specs/paths/eth/miscellaneous/hashrate.yaml#/paths/~1eth~1hashrate
-  # /eth/miscellaneous/getHashrate:
-  #   $ref: ../web3rpc/rpc-specs/paths/eth/miscellaneous/getHashrate.yaml#/paths/~1eth~1getHashrate
-  # /eth/miscellaneous/getWork:
-  #   $ref: ../web3rpc/rpc-specs/paths/eth/miscellaneous/getWork.yaml#/paths/~1eth~1getWork
   /eth/miscellaneous/submitHashrate:
     $ref: ../web3rpc/rpc-specs/paths/eth/miscellaneous/submitHashrate.yaml#/paths/~1eth~1submitHashrate
-
-  # eth/others
-  /eth/createAccessList:
-    $ref: ../web3rpc/rpc-specs/paths/eth/others/createAccessList.yaml#/paths/~1eth~1createAccessList
-  /eth/getRawTransactionByBlockHashAndIndex:
-    $ref: ../web3rpc/rpc-specs/paths/eth/others/getRawTransactionByBlockHashAndIndex.yaml#/paths/~1eth~1getRawTransactionByBlockHashAndIndex
-  /eth/getRawTransactionByBlockNumberAndIndex:
-    $ref: ../web3rpc/rpc-specs/paths/eth/others/getRawTransactionByBlockNumberAndIndex.yaml#/paths/~1eth~1getRawTransactionByBlockNumberAndIndex
-  /eth/getRawTransactionByHash:
-    $ref: ../web3rpc/rpc-specs/paths/eth/others/getRawTransactionByHash.yaml#/paths/~1eth~1getRawTransactionByHash
-  /eth/getProof:
-    $ref: ../web3rpc/rpc-specs/paths/eth/others/getProof.yaml#/paths/~1eth~1getProof
-  /eth/resend:
-    $ref: ../web3rpc/rpc-specs/paths/eth/others/resend.yaml#/paths/~1eth~1resend
+  /eth/miscellaneous/submitWork:
+    $ref: ../web3rpc/rpc-specs/paths/eth/miscellaneous/submitWork.yaml#/paths/~1eth~1submitWork
 
   # net
   /net/listening:
@@ -356,12 +335,12 @@ paths:
     $ref: ../web3rpc/rpc-specs/paths/net/version.yaml#/paths/~1net~1version
 
   # txpool
-  /txpool/status:
-    $ref: ../web3rpc/rpc-specs/paths/txpool/status.yaml#/paths/~1txpool~1status
   /txpool/content:
     $ref: ../web3rpc/rpc-specs/paths/txpool/content.yaml#/paths/~1txpool~1content
   /txpool/inspect:
     $ref: ../web3rpc/rpc-specs/paths/txpool/inspect.yaml#/paths/~1txpool~1inspect
+  /txpool/status:
+    $ref: ../web3rpc/rpc-specs/paths/txpool/status.yaml#/paths/~1txpool~1status
 
   # personal
   /personal/deriveAccount:
@@ -396,136 +375,104 @@ paths:
     $ref: ../web3rpc/rpc-specs/paths/personal/unlockAccount.yaml#/paths/~1personal~1unlockAccount
 
   # debug/logging:
+  /debug/logging/backtraceAt:
+    $ref: ../web3rpc/rpc-specs/paths/debug/logging/backtraceAt.yaml#/paths/~1debug~1backtraceAt
   /debug/logging/setVMLogTarget:
     $ref: ../web3rpc/rpc-specs/paths/debug/logging/setVMLogTarget.yaml#/paths/~1debug~1setVMLogTarget
   /debug/logging/verbosity:
     $ref: ../web3rpc/rpc-specs/paths/debug/logging/verbosity.yaml#/paths/~1debug~1verbosity
-  /debug/logging/verbosityByName:
-    $ref: ../web3rpc/rpc-specs/paths/debug/logging/verbosityByName.yaml#/paths/~1debug~1verbosityByName
   /debug/logging/verbosityByID:
     $ref: ../web3rpc/rpc-specs/paths/debug/logging/verbosityByID.yaml#/paths/~1debug~1verbosityByID
+  /debug/logging/verbosityByName:
+    $ref: ../web3rpc/rpc-specs/paths/debug/logging/verbosityByName.yaml#/paths/~1debug~1verbosityByName
   /debug/logging/vmodule:
     $ref: ../web3rpc/rpc-specs/paths/debug/logging/vmodule.yaml#/paths/~1debug~1vmodule
-  /debug/logging/backtraceAt:
-    $ref: ../web3rpc/rpc-specs/paths/debug/logging/backtraceAt.yaml#/paths/~1debug~1backtraceAt
 
   # debug/blockchainInspection:
-  /debug/blockchainInspection/preimage:
-    $ref: ../web3rpc/rpc-specs/paths/debug/blockchainInspection/preimage.yaml#/paths/~1debug~1preimage
   /debug/blockchainInspection/dumpBlock:
     $ref: ../web3rpc/rpc-specs/paths/debug/blockchainInspection/dumpBlock.yaml#/paths/~1debug~1dumpBlock
   /debug/blockchainInspection/dumpStateTrie:
     $ref: ../web3rpc/rpc-specs/paths/debug/blockchainInspection/dumpStateTrie.yaml#/paths/~1debug~1dumpStateTrie
-  /debug/blockchainInspection/getBlockRlp:
-    $ref: ../web3rpc/rpc-specs/paths/debug/blockchainInspection/getBlockRlp.yaml#/paths/~1debug~1getBlockRlp
-  /debug/blockchainInspection/getModifiedAccountsByNumber:
-    $ref: ../web3rpc/rpc-specs/paths/debug/blockchainInspection/getModifiedAccountsByNumber.yaml#/paths/~1debug~1getModifiedAccountsByNumber
-  /debug/blockchainInspection/getModifiedAccountsByHash:
-    $ref: ../web3rpc/rpc-specs/paths/debug/blockchainInspection/getModifiedAccountsByHash.yaml#/paths/~1debug~1getModifiedAccountsByHash
   /debug/blockchainInspection/getBadBlocks:
     $ref: ../web3rpc/rpc-specs/paths/debug/blockchainInspection/getBadBlocks.yaml#/paths/~1debug~1getBadBlocks
+  /debug/blockchainInspection/getBlockRlp:
+    $ref: ../web3rpc/rpc-specs/paths/debug/blockchainInspection/getBlockRlp.yaml#/paths/~1debug~1getBlockRlp
+  /debug/blockchainInspection/getModifiedAccountsByHash:
+    $ref: ../web3rpc/rpc-specs/paths/debug/blockchainInspection/getModifiedAccountsByHash.yaml#/paths/~1debug~1getModifiedAccountsByHash
+  /debug/blockchainInspection/getModifiedAccountsByNumber:
+    $ref: ../web3rpc/rpc-specs/paths/debug/blockchainInspection/getModifiedAccountsByNumber.yaml#/paths/~1debug~1getModifiedAccountsByNumber
+  /debug/blockchainInspection/preimage:
+    $ref: ../web3rpc/rpc-specs/paths/debug/blockchainInspection/preimage.yaml#/paths/~1debug~1preimage
   /debug/blockchainInspection/printBlock:
     $ref: ../web3rpc/rpc-specs/paths/debug/blockchainInspection/printBlock.yaml#/paths/~1debug~1printBlock
   /debug/blockchainInspection/setHead:
     $ref: ../web3rpc/rpc-specs/paths/debug/blockchainInspection/setHead.yaml#/paths/~1debug~1setHead
-  /debug/blockchainInspection/startWarmUp:
-    $ref: ../web3rpc/rpc-specs/paths/debug/blockchainInspection/startWarmUp.yaml#/paths/~1debug~1startWarmUp
-  /debug/blockchainInspection/startContractWarmUp:
-    $ref: ../web3rpc/rpc-specs/paths/debug/blockchainInspection/startContractWarmUp.yaml#/paths/~1debug~1startContractWarmUp
-  /debug/blockchainInspection/stopWarmUp:
-    $ref: ../web3rpc/rpc-specs/paths/debug/blockchainInspection/stopWarmUp.yaml#/paths/~1debug~1stopWarmUp
   /debug/blockchainInspection/startCollectingTrieStats:
     $ref: ../web3rpc/rpc-specs/paths/debug/blockchainInspection/startCollectingTrieStats.yaml#/paths/~1debug~1startCollectingTrieStats
-
-  # debug/vMTracing:
-  /debug/vMTracing/traceTransaction:
-    $ref: ../web3rpc/rpc-specs/paths/debug/vMTracing/traceTransaction.yaml#/paths/~1debug~1traceTransaction
-  /debug/vMTracing/traceBlockByHash:
-    $ref: ../web3rpc/rpc-specs/paths/debug/vMTracing/traceBlockByHash.yaml#/paths/~1debug~1traceBlockByHash
-  /debug/vMTracing/traceBlockByNumberRange:
-    $ref: ../web3rpc/rpc-specs/paths/debug/vMTracing/traceBlockByNumberRange.yaml#/paths/~1debug~1traceBlockByNumberRange
-  /debug/vMTracing/traceBlockByNumber:
-    $ref: ../web3rpc/rpc-specs/paths/debug/vMTracing/traceBlockByNumber.yaml#/paths/~1debug~1traceBlockByNumber
-  /debug/vMTracing/traceBlockFromFile:
-    $ref: ../web3rpc/rpc-specs/paths/debug/vMTracing/traceBlockFromFile.yaml#/paths/~1debug~1traceBlockFromFile
-  /debug/vMTracing/traceBadBlock:
-    $ref: ../web3rpc/rpc-specs/paths/debug/vMTracing/traceBadBlock.yaml#/paths/~1debug~1traceBadBlock
-  /debug/vMTracing/traceBlock:
-    $ref: ../web3rpc/rpc-specs/paths/debug/vMTracing/traceBlock.yaml#/paths/~1debug~1traceBlock
-  /debug/vMTracing/traceChain:
-    $ref: ../web3rpc/rpc-specs/paths/debug/vMTracing/traceChain.yaml#/paths/~1debug~1traceChain
-
-  # debug/vMStandardTracing:
-  /debug/vMStandardTracing/standardTraceBlockToFile:
-    $ref: ../web3rpc/rpc-specs/paths/debug/vMStandardTracing/standardTraceBlockToFile.yaml#/paths/~1debug~1standardTraceBlockToFile
-  /debug/vMStandardTracing/standardTraceBadBlockToFile:
-    $ref: ../web3rpc/rpc-specs/paths/debug/vMStandardTracing/standardTraceBadBlockToFile.yaml#/paths/~1debug~1standardTraceBadBlockToFile
-
-# debug/profiling:
-  /debug/profiling/startPProf:
-    $ref: ../web3rpc/rpc-specs/paths/debug/profiling/startPProf.yaml#/paths/~1debug~1startPProf
-  /debug/profiling/stopPProf:
-    $ref: ../web3rpc/rpc-specs/paths/debug/profiling/stopPProf.yaml#/paths/~1debug~1stopPProf
-  /debug/profiling/isPProfRunning:
-    $ref: ../web3rpc/rpc-specs/paths/debug/profiling/isPProfRunning.yaml#/paths/~1debug~1isPProfRunning
-
-  # debug/runtimeDebugging:
-  /debug/runtimeDebugging/gcStats:
-    $ref: ../web3rpc/rpc-specs/paths/debug/runtimeDebugging/gcStats.yaml#/paths/~1debug~1gcStats
-  /debug/runtimeDebugging/metrics:
-    $ref: ../web3rpc/rpc-specs/paths/debug/runtimeDebugging/metrics.yaml#/paths/~1debug~1metrics
-  /debug/runtimeDebugging/stacks:
-    $ref: ../web3rpc/rpc-specs/paths/debug/runtimeDebugging/stacks.yaml#/paths/~1debug~1stacks
-  /debug/runtimeDebugging/freeOSMemory:
-    $ref: ../web3rpc/rpc-specs/paths/debug/runtimeDebugging/freeOSMemory.yaml#/paths/~1debug~1freeOSMemory
-  /debug/runtimeDebugging/setGCPercent:
-    $ref: ../web3rpc/rpc-specs/paths/debug/runtimeDebugging/setGCPercent.yaml#/paths/~1debug~1setGCPercent
-  /debug/runtimeDebugging/memStats:
-    $ref: ../web3rpc/rpc-specs/paths/debug/runtimeDebugging/memStats.yaml#/paths/~1debug~1memStats
-
-  # governance
-  /governance/votes:
-    $ref: ../web3rpc/rpc-specs/paths/governance/votes.yaml#/paths/~1governance~1votes
-  /governance/vote:
-    $ref: ../web3rpc/rpc-specs/paths/governance/vote.yaml#/paths/~1governance~1vote
-  /governance/idxCache:
-    $ref: ../web3rpc/rpc-specs/paths/governance/idxCache.yaml#/paths/~1governance~1idxCache
-  /governance/idxCacheFromDb:
-    $ref: ../web3rpc/rpc-specs/paths/governance/idxCacheFromDb.yaml#/paths/~1governance~1idxCacheFromDb
-  /governance/nodeAddress:
-    $ref: ../web3rpc/rpc-specs/paths/governance/nodeAddress.yaml#/paths/~1governance~1nodeAddress
-  /governance/pendingChanges:
-    $ref: ../web3rpc/rpc-specs/paths/governance/pendingChanges.yaml#/paths/~1governance~1pendingChanges
-  /governance/chainConfig:
-    $ref: ../web3rpc/rpc-specs/paths/governance/chainConfig.yaml#/paths/~1governance~1chainConfig
-  /governance/myVotingPower:
-    $ref: ../web3rpc/rpc-specs/paths/governance/myVotingPower.yaml#/paths/~1governance~1myVotingPower
-  /governance/myVotes:
-    $ref: ../web3rpc/rpc-specs/paths/governance/myVotes.yaml#/paths/~1governance~1myVotes
-  /governance/itemsAt:
-    $ref: ../web3rpc/rpc-specs/paths/governance/itemsAt.yaml#/paths/~1governance~1itemsAt
-  /governance/itemCacheFromDb:
-    $ref: ../web3rpc/rpc-specs/paths/governance/itemCacheFromDb.yaml#/paths/~1governance~1itemCacheFromDb
-  /governance/getStakingInfo:
-    $ref: ../web3rpc/rpc-specs/paths/governance/getStakingInfo.yaml#/paths/~1governance~1getStakingInfo
-  /governance/showTally:
-    $ref: ../web3rpc/rpc-specs/paths/governance/showTally.yaml#/paths/~1governance~1showTally
-  /governance/totalVotingPower:
-    $ref: ../web3rpc/rpc-specs/paths/governance/totalVotingPower.yaml#/paths/~1governance~1totalVotingPower
-
-  # debug/others:
-  /debug/getModifiedStorageNodesByNumber:
-    $ref: ../web3rpc/rpc-specs/paths/debug/others/getModifiedStorageNodesByNumber.yaml#/paths/~1debug~1getModifiedStorageNodesByNumber
+  /debug/blockchainInspection/startContractWarmUp:
+    $ref: ../web3rpc/rpc-specs/paths/debug/blockchainInspection/startContractWarmUp.yaml#/paths/~1debug~1startContractWarmUp
+  /debug/blockchainInspection/startWarmUp:
+    $ref: ../web3rpc/rpc-specs/paths/debug/blockchainInspection/startWarmUp.yaml#/paths/~1debug~1startWarmUp
+  /debug/blockchainInspection/stopWarmUp:
+    $ref: ../web3rpc/rpc-specs/paths/debug/blockchainInspection/stopWarmUp.yaml#/paths/~1debug~1stopWarmUp
   /debug/chaindbCompact:
     $ref: ../web3rpc/rpc-specs/paths/debug/others/chaindbCompact.yaml#/paths/~1debug~1chaindbCompact
   /debug/chaindbProperty:
     $ref: ../web3rpc/rpc-specs/paths/debug/others/chaindbProperty.yaml#/paths/~1debug~1chaindbProperty
-  /debug/storageRangeAt:
-    $ref: ../web3rpc/rpc-specs/paths/debug/others/storageRangeAt.yaml#/paths/~1debug~1storageRangeAt
+  /debug/getModifiedStorageNodesByNumber:
+    $ref: ../web3rpc/rpc-specs/paths/debug/others/getModifiedStorageNodesByNumber.yaml#/paths/~1debug~1getModifiedStorageNodesByNumber
   /debug/seedHash:
     $ref: ../web3rpc/rpc-specs/paths/debug/others/seedHash.yaml#/paths/~1debug~1seedHash
+  /debug/storageRangeAt:
+    $ref: ../web3rpc/rpc-specs/paths/debug/others/storageRangeAt.yaml#/paths/~1debug~1storageRangeAt
+
+  # debug/vMTracing:
+  /debug/vMTracing/traceBadBlock:
+    $ref: ../web3rpc/rpc-specs/paths/debug/vMTracing/traceBadBlock.yaml#/paths/~1debug~1traceBadBlock
+  /debug/vMTracing/traceBlock:
+    $ref: ../web3rpc/rpc-specs/paths/debug/vMTracing/traceBlock.yaml#/paths/~1debug~1traceBlock
+  /debug/vMTracing/traceBlockByHash:
+    $ref: ../web3rpc/rpc-specs/paths/debug/vMTracing/traceBlockByHash.yaml#/paths/~1debug~1traceBlockByHash
+  /debug/vMTracing/traceBlockByNumber:
+    $ref: ../web3rpc/rpc-specs/paths/debug/vMTracing/traceBlockByNumber.yaml#/paths/~1debug~1traceBlockByNumber
+  /debug/vMTracing/traceBlockByNumberRange:
+    $ref: ../web3rpc/rpc-specs/paths/debug/vMTracing/traceBlockByNumberRange.yaml#/paths/~1debug~1traceBlockByNumberRange
+  /debug/vMTracing/traceBlockFromFile:
+    $ref: ../web3rpc/rpc-specs/paths/debug/vMTracing/traceBlockFromFile.yaml#/paths/~1debug~1traceBlockFromFile
+  /debug/vMTracing/traceChain:
+    $ref: ../web3rpc/rpc-specs/paths/debug/vMTracing/traceChain.yaml#/paths/~1debug~1traceChain
+  /debug/vMTracing/traceTransaction:
+    $ref: ../web3rpc/rpc-specs/paths/debug/vMTracing/traceTransaction.yaml#/paths/~1debug~1traceTransaction
+
+  # debug/vMStandardTracing:
+  /debug/vMStandardTracing/standardTraceBadBlockToFile:
+    $ref: ../web3rpc/rpc-specs/paths/debug/vMStandardTracing/standardTraceBadBlockToFile.yaml#/paths/~1debug~1standardTraceBadBlockToFile
+  /debug/vMStandardTracing/standardTraceBlockToFile:
+    $ref: ../web3rpc/rpc-specs/paths/debug/vMStandardTracing/standardTraceBlockToFile.yaml#/paths/~1debug~1standardTraceBlockToFile
+
+  # debug/profiling:
+  /debug/profiling/isPProfRunning:
+    $ref: ../web3rpc/rpc-specs/paths/debug/profiling/isPProfRunning.yaml#/paths/~1debug~1isPProfRunning
+  /debug/profiling/startPProf:
+    $ref: ../web3rpc/rpc-specs/paths/debug/profiling/startPProf.yaml#/paths/~1debug~1startPProf
+  /debug/profiling/stopPProf:
+    $ref: ../web3rpc/rpc-specs/paths/debug/profiling/stopPProf.yaml#/paths/~1debug~1stopPProf
   /debug/setMutexProfileFraction:
     $ref: ../web3rpc/rpc-specs/paths/debug/others/setMutexProfileFraction.yaml#/paths/~1debug~1setMutexProfileFraction
+
+  # debug/runtimeDebugging:
+  /debug/runtimeDebugging/freeOSMemory:
+    $ref: ../web3rpc/rpc-specs/paths/debug/runtimeDebugging/freeOSMemory.yaml#/paths/~1debug~1freeOSMemory
+  /debug/runtimeDebugging/gcStats:
+    $ref: ../web3rpc/rpc-specs/paths/debug/runtimeDebugging/gcStats.yaml#/paths/~1debug~1gcStats
+  /debug/runtimeDebugging/memStats:
+    $ref: ../web3rpc/rpc-specs/paths/debug/runtimeDebugging/memStats.yaml#/paths/~1debug~1memStats
+  /debug/runtimeDebugging/metrics:
+    $ref: ../web3rpc/rpc-specs/paths/debug/runtimeDebugging/metrics.yaml#/paths/~1debug~1metrics
+  /debug/runtimeDebugging/setGCPercent:
+    $ref: ../web3rpc/rpc-specs/paths/debug/runtimeDebugging/setGCPercent.yaml#/paths/~1debug~1setGCPercent
+  /debug/runtimeDebugging/stacks:
+    $ref: ../web3rpc/rpc-specs/paths/debug/runtimeDebugging/stacks.yaml#/paths/~1debug~1stacks
 
   # debug/profiling:
   /debug/profiling/blockProfile:
@@ -555,96 +502,126 @@ paths:
   /debug/runtimeTracing/stopGoTrace:
     $ref: ../web3rpc/rpc-specs/paths/debug/runtimeTracing/stopGoTrace.yaml#/paths/~1debug~1stopGoTrace
 
+  # governance
+  /governance/chainConfig:
+    $ref: ../web3rpc/rpc-specs/paths/governance/chainConfig.yaml#/paths/~1governance~1chainConfig
+  /governance/getStakingInfo:
+    $ref: ../web3rpc/rpc-specs/paths/governance/getStakingInfo.yaml#/paths/~1governance~1getStakingInfo
+  /governance/idxCache:
+    $ref: ../web3rpc/rpc-specs/paths/governance/idxCache.yaml#/paths/~1governance~1idxCache
+  /governance/idxCacheFromDb:
+    $ref: ../web3rpc/rpc-specs/paths/governance/idxCacheFromDb.yaml#/paths/~1governance~1idxCacheFromDb
+  /governance/itemCacheFromDb:
+    $ref: ../web3rpc/rpc-specs/paths/governance/itemCacheFromDb.yaml#/paths/~1governance~1itemCacheFromDb
+  /governance/itemsAt:
+    $ref: ../web3rpc/rpc-specs/paths/governance/itemsAt.yaml#/paths/~1governance~1itemsAt
+  /governance/myVotes:
+    $ref: ../web3rpc/rpc-specs/paths/governance/myVotes.yaml#/paths/~1governance~1myVotes
+  /governance/myVotingPower:
+    $ref: ../web3rpc/rpc-specs/paths/governance/myVotingPower.yaml#/paths/~1governance~1myVotingPower
+  /governance/nodeAddress:
+    $ref: ../web3rpc/rpc-specs/paths/governance/nodeAddress.yaml#/paths/~1governance~1nodeAddress
+  /governance/pendingChanges:
+    $ref: ../web3rpc/rpc-specs/paths/governance/pendingChanges.yaml#/paths/~1governance~1pendingChanges
+  /governance/showTally:
+    $ref: ../web3rpc/rpc-specs/paths/governance/showTally.yaml#/paths/~1governance~1showTally
+  /governance/totalVotingPower:
+    $ref: ../web3rpc/rpc-specs/paths/governance/totalVotingPower.yaml#/paths/~1governance~1totalVotingPower
+  /governance/vote:
+    $ref: ../web3rpc/rpc-specs/paths/governance/vote.yaml#/paths/~1governance~1vote
+  /governance/votes:
+    $ref: ../web3rpc/rpc-specs/paths/governance/votes.yaml#/paths/~1governance~1votes
+
   # admin
   /admin/addPeer:
     $ref: ../web3rpc/rpc-specs/paths/admin/addPeer.yaml#/paths/~1admin~1addPeer
+  /admin/datadir:
+    $ref: ../web3rpc/rpc-specs/paths/admin/datadir.yaml#/paths/~1admin~1datadir
   /admin/exportChain:
     $ref: ../web3rpc/rpc-specs/paths/admin/exportChain.yaml#/paths/~1admin~1exportChain
+  /admin/getSpamThrottlerCandidateList:
+    $ref: ../web3rpc/rpc-specs/paths/admin/getSpamThrottlerCandidateList.yaml#/paths/~1admin~1getSpamThrottlerCandidateList
+  /admin/getSpamThrottlerThrottleList:
+    $ref: ../web3rpc/rpc-specs/paths/admin/getSpamThrottlerThrottleList.yaml#/paths/~1admin~1getSpamThrottlerThrottleList
+  /admin/getSpamThrottlerWhiteList:
+    $ref: ../web3rpc/rpc-specs/paths/admin/getSpamThrottlerWhiteList.yaml#/paths/~1admin~1getSpamThrottlerWhiteList
   /admin/importChain:
     $ref: ../web3rpc/rpc-specs/paths/admin/importChain.yaml#/paths/~1admin~1importChain
-  /admin/removePeer:
-    $ref: ../web3rpc/rpc-specs/paths/admin/removePeer.yaml#/paths/~1admin~1removePeer
   /admin/importChainFromString:
     $ref: ../web3rpc/rpc-specs/paths/admin/importChainFromString.yaml#/paths/~1admin~1importChainFromString
-  /admin/startHTTP:
-    $ref: ../web3rpc/rpc-specs/paths/admin/startHTTP.yaml#/paths/~1admin~1startHTTP
-  /admin/stopHTTP:
-    $ref: ../web3rpc/rpc-specs/paths/admin/stopHTTP.yaml#/paths/~1admin~1stopHTTP
-  /admin/startWS:
-    $ref: ../web3rpc/rpc-specs/paths/admin/startWS.yaml#/paths/~1admin~1startWS
-  /admin/stopWS:
-    $ref: ../web3rpc/rpc-specs/paths/admin/stopWS.yaml#/paths/~1admin~1stopWS
-  /admin/startStateMigration:
-    $ref: ../web3rpc/rpc-specs/paths/admin/startStateMigration.yaml#/paths/~1admin~1startStateMigration
-  /admin/stopStateMigration:
-    $ref: ../web3rpc/rpc-specs/paths/admin/stopStateMigration.yaml#/paths/~1admin~1stopStateMigration
-  /admin/saveTrieNodeCacheToDisk:
-    $ref: ../web3rpc/rpc-specs/paths/admin/saveTrieNodeCacheToDisk.yaml#/paths/~1admin~1saveTrieNodeCacheToDisk
-  /admin/setMaxSubscriptionPerWSConn:
-    $ref: ../web3rpc/rpc-specs/paths/admin/setMaxSubscriptionPerWSConn.yaml#/paths/~1admin~1setMaxSubscriptionPerWSConn
   /admin/nodeInfo:
     $ref: ../web3rpc/rpc-specs/paths/admin/nodeInfo.yaml#/paths/~1admin~1nodeInfo
   /admin/peers:
     $ref: ../web3rpc/rpc-specs/paths/admin/peers.yaml#/paths/~1admin~1peers
-  /admin/datadir:
-    $ref: ../web3rpc/rpc-specs/paths/admin/datadir.yaml#/paths/~1admin~1datadir
-  /admin/stateMigrationStatus:
-    $ref: ../web3rpc/rpc-specs/paths/admin/stateMigrationStatus.yaml#/paths/~1admin~1stateMigrationStatus
-  /admin/startSpamThrottler:
-    $ref: ../web3rpc/rpc-specs/paths/admin/startSpamThrottler.yaml#/paths/~1admin~1startSpamThrottler
-  /admin/stopSpamThrottler:
-    $ref: ../web3rpc/rpc-specs/paths/admin/stopSpamThrottler.yaml#/paths/~1admin~1stopSpamThrottler
+  /admin/removePeer:
+    $ref: ../web3rpc/rpc-specs/paths/admin/removePeer.yaml#/paths/~1admin~1removePeer
+  /admin/saveTrieNodeCacheToDisk:
+    $ref: ../web3rpc/rpc-specs/paths/admin/saveTrieNodeCacheToDisk.yaml#/paths/~1admin~1saveTrieNodeCacheToDisk
+  /admin/setMaxSubscriptionPerWSConn:
+    $ref: ../web3rpc/rpc-specs/paths/admin/setMaxSubscriptionPerWSConn.yaml#/paths/~1admin~1setMaxSubscriptionPerWSConn
   /admin/setSpamThrottlerWhiteList:
     $ref: ../web3rpc/rpc-specs/paths/admin/setSpamThrottlerWhiteList.yaml#/paths/~1admin~1setSpamThrottlerWhiteList
-  /admin/getSpamThrottlerWhiteList:
-    $ref: ../web3rpc/rpc-specs/paths/admin/getSpamThrottlerWhiteList.yaml#/paths/~1admin~1getSpamThrottlerWhiteList
-  /admin/getSpamThrottlerThrottleList:
-    $ref: ../web3rpc/rpc-specs/paths/admin/getSpamThrottlerThrottleList.yaml#/paths/~1admin~1getSpamThrottlerThrottleList
-  /admin/getSpamThrottlerCandidateList:
-    $ref: ../web3rpc/rpc-specs/paths/admin/getSpamThrottlerCandidateList.yaml#/paths/~1admin~1getSpamThrottlerCandidateList
   /admin/spamThrottlerConfig:
     $ref: ../web3rpc/rpc-specs/paths/admin/spamThrottlerConfig.yaml#/paths/~1admin~1spamThrottlerConfig
+  /admin/startHTTP:
+    $ref: ../web3rpc/rpc-specs/paths/admin/startHTTP.yaml#/paths/~1admin~1startHTTP
+  /admin/startSpamThrottler:
+    $ref: ../web3rpc/rpc-specs/paths/admin/startSpamThrottler.yaml#/paths/~1admin~1startSpamThrottler
+  /admin/startStateMigration:
+    $ref: ../web3rpc/rpc-specs/paths/admin/startStateMigration.yaml#/paths/~1admin~1startStateMigration
+  /admin/startWS:
+    $ref: ../web3rpc/rpc-specs/paths/admin/startWS.yaml#/paths/~1admin~1startWS
+  /admin/stateMigrationStatus:
+    $ref: ../web3rpc/rpc-specs/paths/admin/stateMigrationStatus.yaml#/paths/~1admin~1stateMigrationStatus
+  /admin/stopHTTP:
+    $ref: ../web3rpc/rpc-specs/paths/admin/stopHTTP.yaml#/paths/~1admin~1stopHTTP
+  /admin/stopSpamThrottler:
+    $ref: ../web3rpc/rpc-specs/paths/admin/stopSpamThrottler.yaml#/paths/~1admin~1stopSpamThrottler
+  /admin/stopStateMigration:
+    $ref: ../web3rpc/rpc-specs/paths/admin/stopStateMigration.yaml#/paths/~1admin~1stopStateMigration
+  /admin/stopWS:
+    $ref: ../web3rpc/rpc-specs/paths/admin/stopWS.yaml#/paths/~1admin~1stopWS
 
   # mainbridge:
+  /mainbridge/convertChildChainBlockHashToParentChainTxHash:
+    $ref: ../web3rpc/rpc-specs/paths/mainbridge/convertChildChainBlockHashToParentChainTxHash.yaml#/paths/~1mainbridge~1convertChildChainBlockHashToParentChainTxHash
   /mainbridge/getChildChainIndexingEnabled:
     $ref: ../web3rpc/rpc-specs/paths/mainbridge/getChildChainIndexingEnabled.yaml#/paths/~1mainbridge~1getChildChainIndexingEnabled
   /mainbridge/nodeInfo:
     $ref: ../web3rpc/rpc-specs/paths/mainbridge/nodeInfo.yaml#/paths/~1mainbridge~1nodeInfo
-  /mainbridge/convertChildChainBlockHashToParentChainTxHash:
-    $ref: ../web3rpc/rpc-specs/paths/mainbridge/convertChildChainBlockHashToParentChainTxHash.yaml#/paths/~1mainbridge~1convertChildChainBlockHashToParentChainTxHash
 
   # subbridge:
-  /subbridge/getReceiptFromParentChain:
-    $ref: ../web3rpc/rpc-specs/paths/subbridge/getReceiptFromParentChain.yaml#/paths/~1subbridge~1getReceiptFromParentChain
-  /subbridge/deployBridge:
-    $ref: ../web3rpc/rpc-specs/paths/subbridge/deployBridge.yaml#/paths/~1subbridge~1deployBridge
-  /subbridge/subscribeBridge:
-    $ref: ../web3rpc/rpc-specs/paths/subbridge/subscribeBridge.yaml#/paths/~1subbridge~1subscribeBridge
-  /subbridge/unsubscribeBridge:
-    $ref: ../web3rpc/rpc-specs/paths/subbridge/unsubscribeBridge.yaml#/paths/~1subbridge~1unsubscribeBridge
-  /subbridge/registerBridge:
-    $ref: ../web3rpc/rpc-specs/paths/subbridge/registerBridge.yaml#/paths/~1subbridge~1registerBridge
-  /subbridge/deregisterBridge:
-    $ref: ../web3rpc/rpc-specs/paths/subbridge/deregisterBridge.yaml#/paths/~1subbridge~1deregisterBridge
-  /subbridge/registerToken:
-    $ref: ../web3rpc/rpc-specs/paths/subbridge/registerToken.yaml#/paths/~1subbridge~1registerToken
-  /subbridge/deregisterToken:
-    $ref: ../web3rpc/rpc-specs/paths/subbridge/deregisterToken.yaml#/paths/~1subbridge~1deregisterToken
-  /subbridge/txPending:
-    $ref: ../web3rpc/rpc-specs/paths/subbridge/txPending.yaml#/paths/~1subbridge~1txPending
-  /subbridge/txPendingCount:
-    $ref: ../web3rpc/rpc-specs/paths/subbridge/txPendingCount.yaml#/paths/~1subbridge~1txPendingCount
-  /subbridge/listBridge:
-    $ref: ../web3rpc/rpc-specs/paths/subbridge/listBridge.yaml#/paths/~1subbridge~1listBridge
-  /subbridge/nodeInfo:
-    $ref: ../web3rpc/rpc-specs/paths/subbridge/nodeInfo.yaml#/paths/~1subbridge~1nodeInfo
   /subbridge/addPeer:
     $ref: ../web3rpc/rpc-specs/paths/subbridge/addPeer.yaml#/paths/~1subbridge~1addPeer
   /subbridge/anchoring:
     $ref: ../web3rpc/rpc-specs/paths/subbridge/anchoring.yaml#/paths/~1subbridge~1anchoring
   /subbridge/convertRequestTxHashToHandleTxHash:
     $ref: ../web3rpc/rpc-specs/paths/subbridge/convertRequestTxHashToHandleTxHash.yaml#/paths/~1subbridge~1convertRequestTxHashToHandleTxHash  
+  /subbridge/deployBridge:
+    $ref: ../web3rpc/rpc-specs/paths/subbridge/deployBridge.yaml#/paths/~1subbridge~1deployBridge
+  /subbridge/deregisterBridge:
+    $ref: ../web3rpc/rpc-specs/paths/subbridge/deregisterBridge.yaml#/paths/~1subbridge~1deregisterBridge
+  /subbridge/deregisterToken:
+    $ref: ../web3rpc/rpc-specs/paths/subbridge/deregisterToken.yaml#/paths/~1subbridge~1deregisterToken
   /subbridge/getBridgeInFormation:
     $ref: ../web3rpc/rpc-specs/paths/subbridge/getBridgeInformation.yaml#/paths/~1subbridge~1getBridgeInformation
+  /subbridge/getReceiptFromParentChain:
+    $ref: ../web3rpc/rpc-specs/paths/subbridge/getReceiptFromParentChain.yaml#/paths/~1subbridge~1getReceiptFromParentChain
+  /subbridge/listBridge:
+    $ref: ../web3rpc/rpc-specs/paths/subbridge/listBridge.yaml#/paths/~1subbridge~1listBridge
+  /subbridge/nodeInfo:
+    $ref: ../web3rpc/rpc-specs/paths/subbridge/nodeInfo.yaml#/paths/~1subbridge~1nodeInfo
+  /subbridge/registerBridge:
+    $ref: ../web3rpc/rpc-specs/paths/subbridge/registerBridge.yaml#/paths/~1subbridge~1registerBridge
+  /subbridge/registerToken:
+    $ref: ../web3rpc/rpc-specs/paths/subbridge/registerToken.yaml#/paths/~1subbridge~1registerToken
   /subbridge/removePeer:
     $ref: ../web3rpc/rpc-specs/paths/subbridge/removePeer.yaml#/paths/~1subbridge~1removePeer
+  /subbridge/subscribeBridge:
+    $ref: ../web3rpc/rpc-specs/paths/subbridge/subscribeBridge.yaml#/paths/~1subbridge~1subscribeBridge
+  /subbridge/txPending:
+    $ref: ../web3rpc/rpc-specs/paths/subbridge/txPending.yaml#/paths/~1subbridge~1txPending
+  /subbridge/txPendingCount:
+    $ref: ../web3rpc/rpc-specs/paths/subbridge/txPendingCount.yaml#/paths/~1subbridge~1txPendingCount
+  /subbridge/unsubscribeBridge:
+    $ref: ../web3rpc/rpc-specs/paths/subbridge/unsubscribeBridge.yaml#/paths/~1subbridge~1unsubscribeBridge

--- a/documentation/scripts.js
+++ b/documentation/scripts.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 
 const regex = /parameters:[\n\s.\-\w:,"$'#\/()\\<>`’]*requestBody:/g;
-const filePath = './web3klaytn.yaml';
+const filePath = './web3rpc.yaml';
 
 // Read the file contents
 let fileContents = fs.readFileSync(filePath, 'utf8');

--- a/documentation/sorting.py
+++ b/documentation/sorting.py
@@ -1,0 +1,48 @@
+import os
+
+in_f = open('index.yaml', "r")
+out_f = open('outIndex.yaml', "w")
+lines = in_f.readlines()
+
+block_dividers = []
+for i in range(len(lines)):
+    temp = lines[i].strip()
+    prev_line = 0
+    if len(temp) != 0 and temp[0] == '#':
+        block_dividers.append(prev_line + i)
+        prev_line = prev_line + i
+
+all_apis = []
+apis = {}
+for i in range(len(block_dividers)):
+    if i == len(block_dividers) - 1:
+        start = block_dividers[i]+1
+        end = len(lines)
+    else:
+        start = block_dividers[i]+1
+        end = block_dividers[i+1]-1
+    
+    for api in range(len(lines[start:end]) // 2):
+        apis[lines[start+api*2]] = [lines[start+api*2], lines[start+api*2+1]]
+
+    all_apis.append(apis)
+    apis = {}
+
+# sorting
+sorted_all_apis = []
+for apis in all_apis:
+    sorted_apis = dict(sorted(apis.items()))
+    sorted_all_apis.append(sorted_apis)
+
+for line in lines[:block_dividers[0]]:
+    out_f.write(line)
+out_f.write('\n')
+for i, apis in enumerate(sorted_all_apis):
+    out_f.write('\n')
+    out_f.write(lines[block_dividers[i]])
+    for key in apis.keys():
+        out_f.write(apis[key][0])
+        out_f.write(apis[key][1])
+
+in_f.close()
+out_f.close()

--- a/web3rpc/rpc-specs/paths/eth/account/accounts.yaml
+++ b/web3rpc/rpc-specs/paths/eth/account/accounts.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/accounts:
     post:
-      summary: "[accounts]"
+      summary: "[Account-accounts]"
       tags:
         - eth
       operationId: accounts

--- a/web3rpc/rpc-specs/paths/eth/account/getBalance.yaml
+++ b/web3rpc/rpc-specs/paths/eth/account/getBalance.yaml
@@ -13,7 +13,7 @@ paths:
   /eth/getBalance:
     post:
       operationId: getBalance
-      summary: "[getBalance]"
+      summary: "[Account-getBalance]"
       description: |
         Returns the balance of the account of given address.
 

--- a/web3rpc/rpc-specs/paths/eth/account/getCode.yaml
+++ b/web3rpc/rpc-specs/paths/eth/account/getCode.yaml
@@ -13,7 +13,7 @@ paths:
   /eth/getCode:
     post:
       operationId: getCode
-      summary: "[getCode]"
+      summary: "[Account-getCode]"
       description: |
         Returns code at a given address.
 

--- a/web3rpc/rpc-specs/paths/eth/account/getTransactionCount.yaml
+++ b/web3rpc/rpc-specs/paths/eth/account/getTransactionCount.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/getTransactionCount:
     post:
-      summary: "[getTransactionCount]"
+      summary: "[Account-getTransactionCount]"
       tags:
         - eth
       operationId: getTransactionCount

--- a/web3rpc/rpc-specs/paths/eth/account/sign.yaml
+++ b/web3rpc/rpc-specs/paths/eth/account/sign.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/sign:
     post:
-      summary: "[sign]"
+      summary: "[Account-sign]"
       tags:
         - eth
       operationId: sign

--- a/web3rpc/rpc-specs/paths/eth/block/blockNumber.yaml
+++ b/web3rpc/rpc-specs/paths/eth/block/blockNumber.yaml
@@ -13,7 +13,7 @@ paths:
   /eth/blockNumber:
     post:
       operationId: blockNumber
-      summary: "[blockNumber]"
+      summary: "[Block-blockNumber]"
       description: |
         Returns the number of the most recent block.
 

--- a/web3rpc/rpc-specs/paths/eth/block/getBlockByHash.yaml
+++ b/web3rpc/rpc-specs/paths/eth/block/getBlockByHash.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/getBlockByHash:
     post:
-      summary: "[getBlockByHash]"
+      summary: "[Block-getBlockByHash]"
       tags:
         - eth
       operationId: getBlockByHash

--- a/web3rpc/rpc-specs/paths/eth/block/getBlockByNumber.yaml
+++ b/web3rpc/rpc-specs/paths/eth/block/getBlockByNumber.yaml
@@ -13,7 +13,7 @@ paths:
   /eth/getBlockByNumber:
     post:
       operationId: getBlockByNumber
-      summary: "[getBlockByNumber]"
+      summary: "[Block-getBlockByNumber]"
       description: |
         Returns information about a block by block number.
 

--- a/web3rpc/rpc-specs/paths/eth/block/getBlockTransactionCountByHash.yaml
+++ b/web3rpc/rpc-specs/paths/eth/block/getBlockTransactionCountByHash.yaml
@@ -13,7 +13,7 @@ paths:
   /eth/getBlockTransactionCountByHash:
     post:
       operationId: getBlockTransactionCountByHash
-      summary: "[getBlockTransactionCountByHash]"
+      summary: "[Block-getBlockTransactionCountByHash]"
       description: |
         Returns the number of transactions in a block from a block that matches the given hash.
 

--- a/web3rpc/rpc-specs/paths/eth/block/getBlockTransactionCountByNumber.yaml
+++ b/web3rpc/rpc-specs/paths/eth/block/getBlockTransactionCountByNumber.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/getBlockTransactionCountByNumber:
     post:
-      summary: "[getBlockTransactionCountByNumber]"
+      summary: "[Block-getBlockTransactionCountByNumber]"
       tags:
         - eth
       operationId: getBlockTransactionCountByNumber

--- a/web3rpc/rpc-specs/paths/eth/block/getHeaderByHash.yaml
+++ b/web3rpc/rpc-specs/paths/eth/block/getHeaderByHash.yaml
@@ -13,7 +13,7 @@ paths:
   /eth/getHeaderByHash:
     post:
       operationId: getHeaderByHash
-      summary: "[getHeaderByHash]"
+      summary: "[Block-getHeaderByHash]"
       description: |
         Returns information about a header by hash.
 

--- a/web3rpc/rpc-specs/paths/eth/block/getHeaderByNumber.yaml
+++ b/web3rpc/rpc-specs/paths/eth/block/getHeaderByNumber.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/getHeaderByNumber:
     post:
-      summary: "[getHeaderByNumber]"
+      summary: "[Block-getHeaderByNumber]"
       tags:
         - eth
       operationId: getHeaderByNumber

--- a/web3rpc/rpc-specs/paths/eth/block/getStorageAt.yaml
+++ b/web3rpc/rpc-specs/paths/eth/block/getStorageAt.yaml
@@ -13,7 +13,7 @@ paths:
   /eth/getStorageAt:
     post:
       operationId: getStorageAt
-      summary: "[getStorageAt]"
+      summary: "[Block-getStorageAt]"
       description: |
         Returns the value from a storage position at a given address
 

--- a/web3rpc/rpc-specs/paths/eth/block/getUncleByBlockHashAndIndex.yaml
+++ b/web3rpc/rpc-specs/paths/eth/block/getUncleByBlockHashAndIndex.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/getUncleByBlockHashAndIndex:
     post:
-      summary: "[getUncleByBlockHashAndIndex]"
+      summary: "[Block-getUncleByBlockHashAndIndex]"
       tags:
         - eth
       operationId: getUncleByBlockHashAndIndex

--- a/web3rpc/rpc-specs/paths/eth/block/getUncleByBlockNumberAndIndex.yaml
+++ b/web3rpc/rpc-specs/paths/eth/block/getUncleByBlockNumberAndIndex.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/getUncleByBlockNumberAndIndex:
     post:
-      summary: "[getUncleByBlockNumberAndIndex]"
+      summary: "[Block-getUncleByBlockNumberAndIndex]"
       tags:
         - eth
       operationId: getUncleByBlockNumberAndIndex

--- a/web3rpc/rpc-specs/paths/eth/block/getUncleCountByBlockHash.yaml
+++ b/web3rpc/rpc-specs/paths/eth/block/getUncleCountByBlockHash.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/getUncleCountByBlockHash:
     post:
-      summary: "[getUncleCountByBlockHash]"
+      summary: "[Block-getUncleCountByBlockHash]"
       tags:
         - eth
       operationId: getUncleCountByBlockHash

--- a/web3rpc/rpc-specs/paths/eth/block/getUncleCountByBlockNumber.yaml
+++ b/web3rpc/rpc-specs/paths/eth/block/getUncleCountByBlockNumber.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/getUncleCountByBlockNumber:
     post:
-      summary: "[getUncleCountByBlockNumber]"
+      summary: "[Block-getUncleCountByBlockNumber]"
       tags:
         - eth
       operationId: getUncleCountByBlockNumber

--- a/web3rpc/rpc-specs/paths/eth/block/mining.yaml
+++ b/web3rpc/rpc-specs/paths/eth/block/mining.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/mining:
     post:
-      summary: "[mining]"
+      summary: "[Block-mining]"
       tags:
         - eth
       operationId: mining

--- a/web3rpc/rpc-specs/paths/eth/block/syncing.yaml
+++ b/web3rpc/rpc-specs/paths/eth/block/syncing.yaml
@@ -13,7 +13,7 @@ paths:
   /eth/syncing:
     post:
       operationId: syncing
-      summary: "[syncing]"
+      summary: "[Block-syncing]"
       description: |
         Returns an object with data about the sync status or false.
 

--- a/web3rpc/rpc-specs/paths/eth/config/chainId.yaml
+++ b/web3rpc/rpc-specs/paths/eth/config/chainId.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/chainId:
     post:
-      summary: "[chainId]"
+      summary: "[Configuration-chainId]"
       tags:
         - eth
       operationId: chainId

--- a/web3rpc/rpc-specs/paths/eth/config/coinbase.yaml
+++ b/web3rpc/rpc-specs/paths/eth/config/coinbase.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/coinbase:
     post:
-      summary: "[coinbase]"
+      summary: "[Configuration-coinbase]"
       tags:
         - eth
       operationId: coinbase

--- a/web3rpc/rpc-specs/paths/eth/config/etherbase.yaml
+++ b/web3rpc/rpc-specs/paths/eth/config/etherbase.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/etherbase:
     post:
-      summary: "[etherbase]"
+      summary: "[Configuration-etherbase]"
       tags:
         - eth
       operationId: etherbase

--- a/web3rpc/rpc-specs/paths/eth/config/gasPrice.yaml
+++ b/web3rpc/rpc-specs/paths/eth/config/gasPrice.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/gasPrice:
     post:
-      summary: "[gasPrice]"
+      summary: "[Configuration-gasPrice]"
       tags:
         - eth
       operationId: gasPrice

--- a/web3rpc/rpc-specs/paths/eth/config/protocolVersion.yaml
+++ b/web3rpc/rpc-specs/paths/eth/config/protocolVersion.yaml
@@ -13,7 +13,7 @@ paths:
   /eth/protocolVersion:
     post:
       operationId: protocolVersion
-      summary: "[protocolVersion]"
+      summary: "[Configuration-protocolVersion]"
       description: |
         Returns the Eth protocol version of the node. The current version (as of v1.9.0) of Cypress/Baobab is istanbul/65.
 

--- a/web3rpc/rpc-specs/paths/eth/filter/getFilterChanges.yaml
+++ b/web3rpc/rpc-specs/paths/eth/filter/getFilterChanges.yaml
@@ -13,7 +13,7 @@ paths:
   /eth/getFilterChanges:
     post:
       operationId: getFilterChanges
-      summary: "[getFilterChanges]"
+      summary: "[Filter-getFilterChanges]"
       description: |
         Polling method for a filter, which returns an array of logs which occurred since last poll.
 

--- a/web3rpc/rpc-specs/paths/eth/filter/getFilterLogs.yaml
+++ b/web3rpc/rpc-specs/paths/eth/filter/getFilterLogs.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/getFilterLogs:
     post:
-      summary: "[getFilterLogs]"
+      summary: "[Filter-getFilterLogs]"
       tags:
         - eth
       operationId: getFilterLogs

--- a/web3rpc/rpc-specs/paths/eth/filter/getLogs.yaml
+++ b/web3rpc/rpc-specs/paths/eth/filter/getLogs.yaml
@@ -13,7 +13,7 @@ paths:
   /eth/getLogs:
     post:
       operationId: getLogs
-      summary: "[getLogs]"
+      summary: "[Filter-getLogs]"
       description: |
         Returns an array of all logs matching a given filter object.
         

--- a/web3rpc/rpc-specs/paths/eth/filter/newBlockFilter.yaml
+++ b/web3rpc/rpc-specs/paths/eth/filter/newBlockFilter.yaml
@@ -13,7 +13,7 @@ paths:
   /eth/newBlockFilter:
     post:
       operationId: newBlockFilter
-      summary: "[newBlockFilter]"
+      summary: "[Filter-newBlockFilter]"
       description: |
         Creates a filter in the node, to notify when a new block arrives. To check if the state has changed, call eth_getFilterChanges.
 

--- a/web3rpc/rpc-specs/paths/eth/filter/newFilter.yaml
+++ b/web3rpc/rpc-specs/paths/eth/filter/newFilter.yaml
@@ -13,7 +13,7 @@ paths:
   /eth/newFilter:
     post:
       operationId: newFilter
-      summary: "[newFilter]"
+      summary: "[Filter-newFilter]"
       description: |
         Creates a filter object, based on filter options, to notify when the state changes (logs).
         - To check if the state has changed, call eth_getFilterChanges.

--- a/web3rpc/rpc-specs/paths/eth/filter/newPendingTransactionFilter.yaml
+++ b/web3rpc/rpc-specs/paths/eth/filter/newPendingTransactionFilter.yaml
@@ -13,7 +13,7 @@ paths:
   /eth/newPendingTransactionFilter:
     post:
       operationId: newPendingTransactionFilter
-      summary: "[newPendingTransactionFilter]"
+      summary: "[Filter-newPendingTransactionFilter]"
       description: |
         Creates a filter in the node, to notify when a new block arrives. To check if the state has changed, call eth_getFilterChanges.
 

--- a/web3rpc/rpc-specs/paths/eth/filter/subscribe.yaml
+++ b/web3rpc/rpc-specs/paths/eth/filter/subscribe.yaml
@@ -13,7 +13,7 @@ paths:
   /eth/subscribe:
     post:
       operationId: subscribe
-      summary: "[subscribe]"
+      summary: "[Filter-subscribe]"
       description: |
         Creates a new subscription to specific events by using either RPC Pub/Sub over WebSockets or filters over HTTP. It allows clients to wait for events instead of polling for them.
         

--- a/web3rpc/rpc-specs/paths/eth/filter/uninstallFilter.yaml
+++ b/web3rpc/rpc-specs/paths/eth/filter/uninstallFilter.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/uninstallFilter:
     post:
-      summary: "[uninstallFilter]"
+      summary: "[Filter-uninstallFilter]"
       tags:
         - eth
       operationId: uninstallFilter

--- a/web3rpc/rpc-specs/paths/eth/filter/unsubscribe.yaml
+++ b/web3rpc/rpc-specs/paths/eth/filter/unsubscribe.yaml
@@ -13,7 +13,7 @@ paths:
   /eth/unsubscribe:
     post:
       operationId: unsubscribe
-      summary: "[unsubscribe]"
+      summary: "[Filter-unsubscribe]"
       description: |
         Cancels the subscription with a specific subscription id by using either RPC Pub/Sub over WebSockets or filters over HTTP. Only the connection that created a subscription can unsubscribe from it.
         

--- a/web3rpc/rpc-specs/paths/eth/gas/feeHistory.yaml
+++ b/web3rpc/rpc-specs/paths/eth/gas/feeHistory.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/feeHistory:
     post:
-      summary: "[feeHistory]"
+      summary: "[Gas-feeHistory]"
       tags:
         - eth
       operationId: feeHistory

--- a/web3rpc/rpc-specs/paths/eth/gas/maxPriorityFeePerGas.yaml
+++ b/web3rpc/rpc-specs/paths/eth/gas/maxPriorityFeePerGas.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/maxPriorityFeePerGas:
     post:
-      summary: "[maxPriorityFeePerGas]"
+      summary: "[Gas-maxPriorityFeePerGas]"
       tags:
         - eth
       operationId: maxPriorityFeePerGas

--- a/web3rpc/rpc-specs/paths/eth/miscellaneous/getHashrate.yaml
+++ b/web3rpc/rpc-specs/paths/eth/miscellaneous/getHashrate.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/getHashrate:
     post:
-      summary: "[getHashrate]"
+      summary: "[Miscellaneous-getHashrate]"
       tags:
         - eth
       operationId: getHashrate

--- a/web3rpc/rpc-specs/paths/eth/miscellaneous/getProof.yaml
+++ b/web3rpc/rpc-specs/paths/eth/miscellaneous/getProof.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/getProof:
     post:
-      summary: "[getProof]"
+      summary: "[Others-getProof]"
       tags:
         - eth
       operationId: getProof

--- a/web3rpc/rpc-specs/paths/eth/miscellaneous/getWork.yaml
+++ b/web3rpc/rpc-specs/paths/eth/miscellaneous/getWork.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/getWork:
     post:
-      summary: "[getWork]"
+      summary: "[Miscellaneous-getWork]"
       tags:
         - eth
       operationId: getWork

--- a/web3rpc/rpc-specs/paths/eth/miscellaneous/hashrate.yaml
+++ b/web3rpc/rpc-specs/paths/eth/miscellaneous/hashrate.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/hashrate:
     post:
-      summary: "[hashrate]"
+      summary: "[Miscellaneous-hashrate]"
       tags:
         - eth
       operationId: hashrate

--- a/web3rpc/rpc-specs/paths/eth/miscellaneous/submitHashrate.yaml
+++ b/web3rpc/rpc-specs/paths/eth/miscellaneous/submitHashrate.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/submitHashrate:
     post:
-      summary: "[submitHashrate]"
+      summary: "[Miscellaneous-submitHashrate]"
       tags:
         - eth
       operationId: submitHashrate

--- a/web3rpc/rpc-specs/paths/eth/miscellaneous/submitWork.yaml
+++ b/web3rpc/rpc-specs/paths/eth/miscellaneous/submitWork.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/submitWork:
     post:
-      summary: "[submitWork]"
+      summary: "[Miscellaneous-submitWork]"
       tags:
         - eth
       operationId: submitWork

--- a/web3rpc/rpc-specs/paths/eth/transaction/call.yaml
+++ b/web3rpc/rpc-specs/paths/eth/transaction/call.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/call:
     post:
-      summary: "[call]"
+      summary: "[Transaction-call]"
       tags:
         - eth
       operationId: call

--- a/web3rpc/rpc-specs/paths/eth/transaction/createAccessList.yaml
+++ b/web3rpc/rpc-specs/paths/eth/transaction/createAccessList.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/createAccessList:
     post:
-      summary: "[createAccessList]"
+      summary: "[Transaction-createAccessList]"
       tags:
         - eth
       operationId: createAccessList

--- a/web3rpc/rpc-specs/paths/eth/transaction/estimateGas.yaml
+++ b/web3rpc/rpc-specs/paths/eth/transaction/estimateGas.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/estimateGas:
     post:
-      summary: "[estimateGas]"
+      summary: "[Transaction-estimateGas]"
       tags:
         - eth
       operationId: estimateGas

--- a/web3rpc/rpc-specs/paths/eth/transaction/fillTransaction.yaml
+++ b/web3rpc/rpc-specs/paths/eth/transaction/fillTransaction.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/fillTransaction:
     post:
-      summary: "[fillTransaction]"
+      summary: "[Transaction-fillTransaction]"
       tags:
         - eth
       operationId: fillTransaction

--- a/web3rpc/rpc-specs/paths/eth/transaction/getRawTransactionByBlockHashAndIndex.yaml
+++ b/web3rpc/rpc-specs/paths/eth/transaction/getRawTransactionByBlockHashAndIndex.yaml
@@ -13,7 +13,7 @@ paths:
   /eth/getRawTransactionByBlockHashAndIndex:
     post:
       operationId: getRawTransactionByBlockHashAndIndex
-      summary: "[getRawTransactionByBlockHashAndIndex]"
+      summary: "[Transaction-getRawTransactionByBlockHashAndIndex]"
       description: |
         GetRawTransactionByBlockHashAndIndex returns the bytes of the transaction for the given block hash and index.
         

--- a/web3rpc/rpc-specs/paths/eth/transaction/getRawTransactionByBlockNumberAndIndex.yaml
+++ b/web3rpc/rpc-specs/paths/eth/transaction/getRawTransactionByBlockNumberAndIndex.yaml
@@ -13,7 +13,7 @@ paths:
   /eth/getRawTransactionByBlockNumberAndIndex:
     post:
       operationId: getRawTransactionByBlockNumberAndIndex
-      summary: "[getRawTransactionByBlockNumberAndIndex]"
+      summary: "[Transaction-getRawTransactionByBlockNumberAndIndex]"
       tags:
         - eth
       description: |

--- a/web3rpc/rpc-specs/paths/eth/transaction/getRawTransactionByHash.yaml
+++ b/web3rpc/rpc-specs/paths/eth/transaction/getRawTransactionByHash.yaml
@@ -10,17 +10,17 @@ servers:
   - url: http://localhost:7151
 
 paths:
-  /klay/getRawTransactionByHash:
+  /eth/getRawTransactionByHash:
     post:
       operationId: getRawTransactionByHash
-      summary: "[getRawTransactionByHash]"
+      summary: "[Transaction-getRawTransactionByHash]"
       description: |
         GetRawTransactionByHash returns the bytes of the transaction for the given hash.
 
-        **JSONRPC:** `klay_getRawTransactionByHash`
+        **JSONRPC:** `eth_getRawTransactionByHash`
 
       tags:
-        - klay
+        - eth
 
       parameters:
         - name: hash
@@ -37,7 +37,7 @@ paths:
             schema:
               allOf:
                 - $ref: "../../../components/requests/JsonRpcRequest.yaml#/components/schemas/JsonRpcRequest"
-                - $ref: "#/components/schemas/KlayGetRawTransactionByHashReq"
+                - $ref: "#/components/schemas/EthGetRawTransactionByHashReq"
 
       responses:
         200:
@@ -47,28 +47,28 @@ paths:
               schema:
                 allOf:
                   - $ref: "../../../components/responses/JsonRpcResponse.yaml#/components/schemas/JsonRpcResponse"
-                  - $ref: "#/components/schemas/KlayGetRawTransactionByHashResp"
+                  - $ref: "#/components/schemas/EthGetRawTransactionByHashResp"
 
       x-codeSamples:
         - lang: "curl"
           label: "Curl"
           source:
-            $ref: "../../../code-samples/curl/klay/others/getRawTransactionByHash.sh"
+            $ref: "../../../code-samples/curl/eth/others/getRawTransactionByHash.sh"
         - lang: "java"
           label: "Java"
           source:
-            $ref: "../../../code-samples/java/src/main/java/opensdk/sdk/apis/klay/others/KlayGetRawTransactionByHashExample.java"
+            $ref: "../../../code-samples/java/src/main/java/opensdk/sdk/apis/eth/others/EthGetRawTransactionByHashExample.java"
         - lang: "javascript"
           label: "Javascript"
           source:
-            $ref: "../../../code-samples/javascript/klay/transaction/getRawTransactionByHash.js"
+            $ref: "../../../code-samples/javascript/eth/transaction/getRawTransactionByHash.js"
         - lang: "python"
           label: "Python"
           source:
             $ref: "../../../code-samples/python/klay/others/getRawTransactionByHash.py"
 components:
   schemas:
-    KlayGetRawTransactionByHashReq:
+    EthGetRawTransactionByHashReq:
       type: object
       required:
         - method
@@ -76,17 +76,20 @@ components:
       properties:
         method:
           type: string
-          default: 'klay_getRawTransactionByHash'
+          default: "eth_getRawTransactionByHash"
         params:
           type: array
+          description: Hex representation of a Keccak 256 hash
           items:
-            title: hash
+            title: Hash
             type: string
             format: hex
-          description: Hex representation of a Keccak 256 hash
-          example:  ["0x29b6cd965c7d9a53a6f068da259dce1d3810ba79fff8eebac5d4da14754e67e6"]
+          example:
+            [
+              "0x5bbcde52084defa9d1c7068a811363cc27a25c80d7e495180964673aa5f47687",
+            ]
 
-    KlayGetRawTransactionByHashResp:
+    EthGetRawTransactionByHashResp:
       type: object
       properties:
         result:

--- a/web3rpc/rpc-specs/paths/eth/transaction/getTransactionByBlockHashAndIndex.yaml
+++ b/web3rpc/rpc-specs/paths/eth/transaction/getTransactionByBlockHashAndIndex.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/getTransactionByBlockHashAndIndex:
     post:
-      summary: "[getTransactionByBlockHashAndIndex]"
+      summary: "[Transaction-getTransactionByBlockHashAndIndex]"
       tags:
         - eth
       operationId: getTransactionByBlockHashAndIndex

--- a/web3rpc/rpc-specs/paths/eth/transaction/getTransactionByBlockNumberAndIndex.yaml
+++ b/web3rpc/rpc-specs/paths/eth/transaction/getTransactionByBlockNumberAndIndex.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/getTransactionByBlockNumberAndIndex:
     post:
-      summary: "[getTransactionByBlockNumberAndIndex]"
+      summary: "[Transaction-getTransactionByBlockNumberAndIndex]"
       tags:
         - eth
       operationId: getTransactionByBlockNumberAndIndex

--- a/web3rpc/rpc-specs/paths/eth/transaction/getTransactionByHash.yaml
+++ b/web3rpc/rpc-specs/paths/eth/transaction/getTransactionByHash.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/getTransactionByHash:
     post:
-      summary: "[getTransactionByHash]"
+      summary: "[Transaction-getTransactionByHash]"
       tags:
         - eth
       operationId: getTransactionByHash

--- a/web3rpc/rpc-specs/paths/eth/transaction/getTransactionReceipt.yaml
+++ b/web3rpc/rpc-specs/paths/eth/transaction/getTransactionReceipt.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/getTransactionReceipt:
     post:
-      summary: "[getTransactionReceipt]"
+      summary: "[Transaction-getTransactionReceipt]"
       tags:
         - eth
       operationId: getTransactionReceipt

--- a/web3rpc/rpc-specs/paths/eth/transaction/pendingTransactions.yaml
+++ b/web3rpc/rpc-specs/paths/eth/transaction/pendingTransactions.yaml
@@ -13,7 +13,7 @@ paths:
   /eth/pendingTransactions:
     post:
       operationId: pendingTransactions
-      summary: "[pendingTransactions]"
+      summary: "[Transaction-pendingTransactions]"
       tags:
         - eth
       description: |

--- a/web3rpc/rpc-specs/paths/eth/transaction/resend.yaml
+++ b/web3rpc/rpc-specs/paths/eth/transaction/resend.yaml
@@ -13,7 +13,7 @@ paths:
   /eth/resend:
     post:
       operationId: resend
-      summary: "[resend]"
+      summary: "[Transaction-resend]"
       description: |
         Resend accepts an existing transaction and a new gas price and limit. It will remove the given transaction from the pool and reinsert it with the new gas price and limit.
 

--- a/web3rpc/rpc-specs/paths/eth/transaction/sendRawTransaction.yaml
+++ b/web3rpc/rpc-specs/paths/eth/transaction/sendRawTransaction.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/sendRawTransaction:
     post:
-      summary: "[sendRawTransaction]"
+      summary: "[Transaction-sendRawTransaction]"
       tags:
         - eth
       operationId: sendRawTransaction

--- a/web3rpc/rpc-specs/paths/eth/transaction/sendTransaction.yaml
+++ b/web3rpc/rpc-specs/paths/eth/transaction/sendTransaction.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/sendTransaction:
     post:
-      summary: "[sendTransaction]"
+      summary: "[Transaction-sendTransaction]"
       tags:
         - eth
       operationId: sendTransaction

--- a/web3rpc/rpc-specs/paths/eth/transaction/signTransaction.yaml
+++ b/web3rpc/rpc-specs/paths/eth/transaction/signTransaction.yaml
@@ -12,7 +12,7 @@ servers:
 paths:
   /eth/signTransaction:
     post:
-      summary: "[signTransaction]"
+      summary: "[Transaction-signTransaction]"
       tags:
         - eth
       operationId: signTransaction

--- a/web3rpc/rpc-specs/paths/klay/account/accountCreated.yaml
+++ b/web3rpc/rpc-specs/paths/klay/account/accountCreated.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/accountCreated:
     post:
       operationId: accountCreated
-      summary: "[accountCreated]"
+      summary: "[Account-accountCreated]"
       description: |
         Returns `true` if the account associated with the address is created. It returns `false` otherwise.
 

--- a/web3rpc/rpc-specs/paths/klay/account/accounts.yaml
+++ b/web3rpc/rpc-specs/paths/klay/account/accounts.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/accounts:
     post:
       operationId: accounts
-      summary: "[accounts]"
+      summary: "[Account-accounts]"
       description: |
         Returns a list of addresses owned by client.
         

--- a/web3rpc/rpc-specs/paths/klay/account/decodeAccountKey.yaml
+++ b/web3rpc/rpc-specs/paths/klay/account/decodeAccountKey.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/decodeAccountKey:
     post:
       operationId: decodeAccountKey
-      summary: "[decodeAccountKey]"
+      summary: "[Account-decodeAccountKey]"
       description: |
         Decodes an RLP encoded account key.
 

--- a/web3rpc/rpc-specs/paths/klay/account/encodeAccountKey.yaml
+++ b/web3rpc/rpc-specs/paths/klay/account/encodeAccountKey.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/encodeAccountKey:
     post:
       operationId: encodeAccountKey
-      summary: "[encodeAccountKey]"
+      summary: "[Account-encodeAccountKey]"
       description: |
         Encodes an account key using the Recursive Length Prefix (RLP) encoding scheme.
 

--- a/web3rpc/rpc-specs/paths/klay/account/getAccount.yaml
+++ b/web3rpc/rpc-specs/paths/klay/account/getAccount.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getAccount:
     post:
       operationId: getAccount
-      summary: "[getAccount]"
+      summary: "[Account-getAccount]"
       description: |
         Returns the account information of a given address. There are two different account types in Klaytn: Externally Owned Account (EOA) and Smart Contract Account. See Klaytn Accounts.
 

--- a/web3rpc/rpc-specs/paths/klay/account/getAccountKey.yaml
+++ b/web3rpc/rpc-specs/paths/klay/account/getAccountKey.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getAccountKey:
     post:
       operationId: getAccountKey
-      summary: "[getAccountKey]"
+      summary: "[Account-getAccountKey]"
       description: |
         Returns the account key of the Externally Owned Account (EOA) of a given address. If the account has AccountKeyLegacy or the account of the given address is a Smart Contract Account, it will return an empty key value.
 

--- a/web3rpc/rpc-specs/paths/klay/account/getBalance.yaml
+++ b/web3rpc/rpc-specs/paths/klay/account/getBalance.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getBalance:
     post:
       operationId: getBalance
-      summary: "[getBalance]"
+      summary: "[Account-getBalance]"
       description: |
         Returns the balance of the account of given address.
 

--- a/web3rpc/rpc-specs/paths/klay/account/getCode.yaml
+++ b/web3rpc/rpc-specs/paths/klay/account/getCode.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getCode:
     post:
       operationId: getCode
-      summary: "[getCode]"
+      summary: "[Account-getCode]"
       description: |
         Returns code at a given address.
 

--- a/web3rpc/rpc-specs/paths/klay/account/getTransactionCount.yaml
+++ b/web3rpc/rpc-specs/paths/klay/account/getTransactionCount.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getTransactionCount:
     post:
       operationId: getTransactionCount
-      summary: "[getTransactionCount]"
+      summary: "[Account-getTransactionCount]"
       description: |
         Returns the number of transactions sent from an address.
 

--- a/web3rpc/rpc-specs/paths/klay/account/isContractAccount.yaml
+++ b/web3rpc/rpc-specs/paths/klay/account/isContractAccount.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/isContractAccount:
     post:
       operationId: isContractAccount
-      summary: "[isContractAccount]"
+      summary: "[Account-isContractAccount]"
       description: |
         Returns true if an input account has a non-empty codeHash at the time of a specific block number. It returns false if the account is an EOA or a smart contract account which doesn't have codeHash.
 

--- a/web3rpc/rpc-specs/paths/klay/account/sign.yaml
+++ b/web3rpc/rpc-specs/paths/klay/account/sign.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/sign:
     post:
       operationId: sign
-      summary: "[sign]"
+      summary: "[Account-sign]"
       description: |
         The sign method calculates a Klaytn-specific signature with:
 

--- a/web3rpc/rpc-specs/paths/klay/block/blockNumber.yaml
+++ b/web3rpc/rpc-specs/paths/klay/block/blockNumber.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/blockNumber:
     post:
       operationId: blockNumber
-      summary: "[blockNumber]"
+      summary: "[Block-blockNumber]"
       description: |
         Returns the number of most recent block.
 

--- a/web3rpc/rpc-specs/paths/klay/block/getBlockByHash.yaml
+++ b/web3rpc/rpc-specs/paths/klay/block/getBlockByHash.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getBlockByHash:
     post:
       operationId: getBlockByHash
-      summary: "[getBlockByHash]"
+      summary: "[Block-getBlockByHash]"
       description: |
         Returns information about a block by hash. This API works only on RPC call, not on JavaScript console.
         

--- a/web3rpc/rpc-specs/paths/klay/block/getBlockByNumber.yaml
+++ b/web3rpc/rpc-specs/paths/klay/block/getBlockByNumber.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getBlockByNumber:
     post:
       operationId: getBlockByNumber
-      summary: "[getBlockByNumber]"
+      summary: "[Block-getBlockByNumber]"
       description: |
         Returns information about a block by block number. This API works only on RPC call, not on JavaScript console.
 

--- a/web3rpc/rpc-specs/paths/klay/block/getBlockReceipts.yaml
+++ b/web3rpc/rpc-specs/paths/klay/block/getBlockReceipts.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getBlockReceipts:
     post:
       operationId: getBlockReceipts
-      summary: "[getBlockReceipts]"
+      summary: "[Block-getBlockReceipts]"
       description: |
         Returns receipts included in a block identified by block hash.
 

--- a/web3rpc/rpc-specs/paths/klay/block/getBlockTransactionCountByHash.yaml
+++ b/web3rpc/rpc-specs/paths/klay/block/getBlockTransactionCountByHash.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getBlockTransactionCountByHash:
     post:
       operationId: getBlockTransactionCountByHash
-      summary: "[getBlockTransactionCountByHash]"
+      summary: "[Block-getBlockTransactionCountByHash]"
       description: |
         Returns the number of transactions in a block from a block that matches the given hash.
         

--- a/web3rpc/rpc-specs/paths/klay/block/getBlockTransactionCountByNumber.yaml
+++ b/web3rpc/rpc-specs/paths/klay/block/getBlockTransactionCountByNumber.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getBlockTransactionCountByNumber:
     post:
       operationId: getBlockTransactionCountByNumber
-      summary: "[getBlockTransactionCountByNumber]"
+      summary: "[Block-getBlockTransactionCountByNumber]"
       description: |
         Returns the number of transactions in a block matching the given block number.
         

--- a/web3rpc/rpc-specs/paths/klay/block/getBlockWithConsensusInfoByHash.yaml
+++ b/web3rpc/rpc-specs/paths/klay/block/getBlockWithConsensusInfoByHash.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getBlockWithConsensusInfoByHash:
     post:
       operationId: getBlockWithConsensusInfoByHash
-      summary: "[getBlockWithConsensusInfoByHash]"
+      summary: "[Block-getBlockWithConsensusInfoByHash]"
       description: |
         Returns a block with consensus information that matches the given hash.
 

--- a/web3rpc/rpc-specs/paths/klay/block/getBlockWithConsensusInfoByNumber.yaml
+++ b/web3rpc/rpc-specs/paths/klay/block/getBlockWithConsensusInfoByNumber.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getBlockWithConsensusInfoByNumber:
     post:
       operationId: getBlockWithConsensusInfoByNumber
-      summary: "[getBlockWithConsensusInfoByNumber]"
+      summary: "[Block-getBlockWithConsensusInfoByNumber]"
       description: |
         Returns a block with consensus information that matches the given block number.
 

--- a/web3rpc/rpc-specs/paths/klay/block/getBlockWithConsensusInfoByNumberRange.yaml
+++ b/web3rpc/rpc-specs/paths/klay/block/getBlockWithConsensusInfoByNumberRange.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getBlockWithConsensusInfoByNumberRange:
     post:
       operationId: getBlockWithConsensusInfoByNumberRange
-      summary: "[getBlockWithConsensusInfoByNumberRange]"
+      summary: "[Block-getBlockWithConsensusInfoByNumberRange]"
       description: |
         Returns a block with consensus information matched by the given block hash or block number.
 

--- a/web3rpc/rpc-specs/paths/klay/block/getCommittee.yaml
+++ b/web3rpc/rpc-specs/paths/klay/block/getCommittee.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getCommittee:
     post:
       operationId: getCommittee
-      summary: "[getCommittee]"
+      summary: "[Block-getCommittee]"
       description: |
         Returns a list of all validators in the committee at the specified block. If the parameter is not set, returns a list of all validators in the committee at the latest block.
 

--- a/web3rpc/rpc-specs/paths/klay/block/getCommitteeSize.yaml
+++ b/web3rpc/rpc-specs/paths/klay/block/getCommitteeSize.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getCommitteeSize:
     post:
       operationId: getCommitteeSize
-      summary: "[getCommitteeSize]"
+      summary: "[Block-getCommitteeSize]"
       description: |
         Returns the size of the committee at the specified block. If the parameter is not set, returns the size of the committee at the latest block.
 

--- a/web3rpc/rpc-specs/paths/klay/block/getCouncil.yaml
+++ b/web3rpc/rpc-specs/paths/klay/block/getCouncil.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getCouncil:
     post:
       operationId: getCouncil
-      summary: "[getCouncil]"
+      summary: "[Block-getCouncil]"
       description: |
         Returns a list of all validators of the council at the specified block. If the parameter is not set, returns a list of all validators of the council at the latest block.
 

--- a/web3rpc/rpc-specs/paths/klay/block/getCouncilSize.yaml
+++ b/web3rpc/rpc-specs/paths/klay/block/getCouncilSize.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getCouncilSize:
     post:
       operationId: getCouncilSize
-      summary: "[getCouncilSize]"
+      summary: "[Block-getCouncilSize]"
       description: |
         Returns the size of the council at the specified block. If the parameter is not set, returns the size of the council at the latest block.
 

--- a/web3rpc/rpc-specs/paths/klay/block/getHeaderByHash.yaml
+++ b/web3rpc/rpc-specs/paths/klay/block/getHeaderByHash.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getHeaderByHash:
     post:
       operationId: getHeaderByHash
-      summary: "[getHeaderByHash]"
+      summary: "[Block-getHeaderByHash]"
       description: |
         Returns information about a header by hash. This API works only on RPC call, not on JavaScript console.
 

--- a/web3rpc/rpc-specs/paths/klay/block/getHeaderByNumber.yaml
+++ b/web3rpc/rpc-specs/paths/klay/block/getHeaderByNumber.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getHeaderByNumber:
     post:
       operationId: getHeaderByNumber
-      summary: "[getHeaderByNumber]"
+      summary: "[Block-getHeaderByNumber]"
       description: |
         Returns information about a header by number. This API works only on RPC call, not on JavaScript console.
 

--- a/web3rpc/rpc-specs/paths/klay/block/getRewards.yaml
+++ b/web3rpc/rpc-specs/paths/klay/block/getRewards.yaml
@@ -15,7 +15,7 @@ paths:
       tags:
         - klay
       operationId: getRewards
-      summary: "[getRewards]"
+      summary: "[Block-getRewards]"
       description: |
         Returns the reward distribution result about a block by block number, including the rewardees and their shares. If the parameter is not set, it returns the reward distribution at the latest block.
 

--- a/web3rpc/rpc-specs/paths/klay/block/getStorageAt.yaml
+++ b/web3rpc/rpc-specs/paths/klay/block/getStorageAt.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getStorageAt:
     post:
       operationId: getStorageAt
-      summary: "[getStorageAt]"
+      summary: "[Block-getStorageAt]"
       description: |
         Returns the value from a storage position at a given address.
 

--- a/web3rpc/rpc-specs/paths/klay/block/syncing.yaml
+++ b/web3rpc/rpc-specs/paths/klay/block/syncing.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/syncing:
     post:
       operationId: syncing
-      summary: "[syncing]"
+      summary: "[Block-syncing]"
       description: |
         Returns an object with data about the sync status or false.
 

--- a/web3rpc/rpc-specs/paths/klay/configuration/chainID.yaml
+++ b/web3rpc/rpc-specs/paths/klay/configuration/chainID.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/chainID:
     post:
       operationId: chainID
-      summary: "[chainID]"
+      summary: "[Configuration-chainID]"
       description: |
         Returns the chain ID of the chain.
 

--- a/web3rpc/rpc-specs/paths/klay/configuration/clientVersion.yaml
+++ b/web3rpc/rpc-specs/paths/klay/configuration/clientVersion.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/clientVersion:
     post:
       operationId: clientVersion
-      summary: "[clientVersion]"
+      summary: "[Configuration-clientVersion]"
       description: |
         Returns the current client version of a Klaytn node.
 

--- a/web3rpc/rpc-specs/paths/klay/configuration/gasPrice.yaml
+++ b/web3rpc/rpc-specs/paths/klay/configuration/gasPrice.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/gasPrice:
     post:
       operationId: gasPrice
-      summary: "[gasPrice]"
+      summary: "[Configuration-gasPrice]"
       description: |
         Returns a suggestion for a gas price in peb.
         

--- a/web3rpc/rpc-specs/paths/klay/configuration/gasPriceAt.yaml
+++ b/web3rpc/rpc-specs/paths/klay/configuration/gasPriceAt.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/gasPriceAt:
     post:
       operationId: gasPriceAt
-      summary: "[gasPriceAt]"
+      summary: "[Configuration-gasPriceAt]"
       description: |
         Returns different values based on the condition described below. The unit of the return value is peb.
         

--- a/web3rpc/rpc-specs/paths/klay/configuration/getChainConfig.yaml
+++ b/web3rpc/rpc-specs/paths/klay/configuration/getChainConfig.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getChainConfig:
     post:
       operationId: getChainConfig
-      summary: "[getChainConfig]"
+      summary: "[Configuration-getChainConfig]"
       description: |
         Returns the configuration of the chain.
 

--- a/web3rpc/rpc-specs/paths/klay/configuration/isParallelDBWrite.yaml
+++ b/web3rpc/rpc-specs/paths/klay/configuration/isParallelDBWrite.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/isParallelDBWrite:
     post:
       operationId: isParallelDBWrite
-      summary: "[isParallelDBWrite]"
+      summary: "[Configuration-isParallelDBWrite]"
       description: |
         Returns true if the node is writing blockchain data in parallel manner. It is enabled by default.
 

--- a/web3rpc/rpc-specs/paths/klay/configuration/isSenderTxHashIndexingEnabled.yaml
+++ b/web3rpc/rpc-specs/paths/klay/configuration/isSenderTxHashIndexingEnabled.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/isSenderTxHashIndexingEnabled:
     post:
       operationId: isSenderTxHashIndexingEnabled
-      summary: "[isSenderTxHashIndexingEnabled]"
+      summary: "[Configuration-isSenderTxHashIndexingEnabled]"
       description: |
         Returns true if the node is indexing sender transaction hash to transaction hash mapping information. It is disabled by default and can be enabled by --sendertxhashindexing.
 

--- a/web3rpc/rpc-specs/paths/klay/configuration/protocolVersion.yaml
+++ b/web3rpc/rpc-specs/paths/klay/configuration/protocolVersion.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/protocolVersion:
     post:
       operationId: protocolVersion
-      summary: "[protocolVersion]"
+      summary: "[Configuration-protocolVersion]"
       description: |
         Returns the Klaytn protocol version of the node. The current version (as of v1.9.0) of Cypress/Baobab is istanbul/65.
 

--- a/web3rpc/rpc-specs/paths/klay/configuration/rewardBase.yaml
+++ b/web3rpc/rpc-specs/paths/klay/configuration/rewardBase.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/rewardbase:
     post:
       operationId: rewardbase
-      summary: "[rewardbase]"
+      summary: "[Configuration-rewardbase]"
       description: |
         Returns the rewardbase of the current node. Rewardbase is the address of the account where the block rewards goes to. It is only required for CNs.
 

--- a/web3rpc/rpc-specs/paths/klay/filter/getFilterChanges.yaml
+++ b/web3rpc/rpc-specs/paths/klay/filter/getFilterChanges.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getFilterChanges:
     post:
       operationId: getFilterChanges
-      summary: "[getFilterChanges]"
+      summary: "[Filter-getFilterChanges]"
       description: |
         Polling method for a filter, which returns an array of logs which occurred since last poll.
 

--- a/web3rpc/rpc-specs/paths/klay/filter/getFilterLogs.yaml
+++ b/web3rpc/rpc-specs/paths/klay/filter/getFilterLogs.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getFilterLogs:
     post:
       operationId: getFilterLogs
-      summary: "[getFilterLogs]"
+      summary: "[Filter-getFilterLogs]"
       description: |
         Returns an array of all logs matching filter with given id, which has been obtained using klay_newFilter.Note that filter ids returned by other filter creation functions, such as klay_newBlockFilter or klay_newPendingTransactionFilter, cannot be used with this function.
 

--- a/web3rpc/rpc-specs/paths/klay/filter/getLogs.yaml
+++ b/web3rpc/rpc-specs/paths/klay/filter/getLogs.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getLogs:
     post:
       operationId: getLogs
-      summary: "[getLogs]"
+      summary: "[Filter-getLogs]"
       description: |
         Returns an array of all logs matching a given filter object.
 

--- a/web3rpc/rpc-specs/paths/klay/filter/newBlockFilter.yaml
+++ b/web3rpc/rpc-specs/paths/klay/filter/newBlockFilter.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/newBlockFilter:
     post:
       operationId: newBlockFilter
-      summary: "[newBlockFilter]"
+      summary: "[Filter-newBlockFilter]"
       description: |
         Creates a filter in the node, to notify when a new block arrives. To check if the state has changed, call klay_getFilterChanges.
 

--- a/web3rpc/rpc-specs/paths/klay/filter/newFilter.yaml
+++ b/web3rpc/rpc-specs/paths/klay/filter/newFilter.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/newFilter:
     post:
       operationId: newFilter
-      summary: "[newFilter]"
+      summary: "[Filter-newFilter]"
       description: |
         Creates a filter object, based on filter options, to notify when the state changes (logs).
         - To check if the state has changed, call klay_getFilterChanges.

--- a/web3rpc/rpc-specs/paths/klay/filter/newPendingTransactionFilter.yaml
+++ b/web3rpc/rpc-specs/paths/klay/filter/newPendingTransactionFilter.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/newPendingTransactionFilter:
     post:
       operationId: newPendingTransactionFilter
-      summary: "[newPendingTransactionFilter]"
+      summary: "[Filter-newPendingTransactionFilter]"
       description: |
         Creates a filter in the node, to notify when new pending transactions arrive. To check if the state has changed, call klay_getFilterChanges.
 

--- a/web3rpc/rpc-specs/paths/klay/filter/subscribe.yaml
+++ b/web3rpc/rpc-specs/paths/klay/filter/subscribe.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/subscribe:
     post:
       operationId: subscribe
-      summary: "[subscribe]"
+      summary: "[Filter-subscribe]"
       description: |
         Creates a new subscription to specific events by using either RPC Pub/Sub over WebSockets or filters over HTTP. It allows clients to wait for events instead of polling for them.
         

--- a/web3rpc/rpc-specs/paths/klay/filter/uninstallFilter.yaml
+++ b/web3rpc/rpc-specs/paths/klay/filter/uninstallFilter.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/uninstallFilter:
     post:
       operationId: uninstallFilter
-      summary: "[uninstallFilter]"
+      summary: "[Filter-uninstallFilter]"
       description: |
         Uninstalls a filter with given id. Should always be called when watch is no longer needed. Additionally, filters timeout when they are not requested with klay_getFilterChanges for a period of time.
 

--- a/web3rpc/rpc-specs/paths/klay/filter/unsubscribe.yaml
+++ b/web3rpc/rpc-specs/paths/klay/filter/unsubscribe.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/unsubscribe:
     post:
       operationId: unsubscribe
-      summary: "[unsubscribe]"
+      summary: "[Filter-unsubscribe]"
       description: |
         Cancels the subscription with a specific subscription id by using either RPC Pub/Sub over WebSockets or filters over HTTP. Only the connection that created a subscription can unsubscribe from it.
         

--- a/web3rpc/rpc-specs/paths/klay/gas/feeHistory.yaml
+++ b/web3rpc/rpc-specs/paths/klay/gas/feeHistory.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/feeHistory:
     post:
       operationId: feeHistory
-      summary: "[feeHistory]"
+      summary: "[Gas-feeHistory]"
       description: |
         Returns base fee per gas and transaction effective priority fee per gas history for the requested block range if available.
 

--- a/web3rpc/rpc-specs/paths/klay/gas/lowerBoundGasPrice.yaml
+++ b/web3rpc/rpc-specs/paths/klay/gas/lowerBoundGasPrice.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/lowerBoundGasPrice:
     post:
       operationId: lowerBoundGasPrice
-      summary: "[lowerBoundGasPrice]"
+      summary: "[Gas-lowerBoundGasPrice]"
       description: |
         Returns lower bound gas price.
 

--- a/web3rpc/rpc-specs/paths/klay/gas/maxPriorityFeePerGas.yaml
+++ b/web3rpc/rpc-specs/paths/klay/gas/maxPriorityFeePerGas.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/maxPriorityFeePerGas:
     post:
       operationId: maxPriorityFeePerGas
-      summary: "[maxPriorityFeePerGas]"
+      summary: "[Gas-maxPriorityFeePerGas]"
       description: |
         Returns a suggestion for a gas tip cap for dynamic fee transactions in peb.
 

--- a/web3rpc/rpc-specs/paths/klay/gas/upperBoundGasPrice.yaml
+++ b/web3rpc/rpc-specs/paths/klay/gas/upperBoundGasPrice.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/upperBoundGasPrice:
     post:
       operationId: upperBoundGasPrice
-      summary: "[upperBoundGasPrice]"
+      summary: "[Gas-upperBoundGasPrice]"
       description: |
         Returns upper bound gas price.
 

--- a/web3rpc/rpc-specs/paths/klay/miscellaneous/getStakingInfo.yaml
+++ b/web3rpc/rpc-specs/paths/klay/miscellaneous/getStakingInfo.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getStakingInfo:
     post:
       operationId: getStakingInfo
-      summary: "[getStakingInfo]"
+      summary: "[Miscellaneous-getStakingInfo]"
       tags:
         - klay
       description: |

--- a/web3rpc/rpc-specs/paths/klay/miscellaneous/nodeAddress.yaml
+++ b/web3rpc/rpc-specs/paths/klay/miscellaneous/nodeAddress.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/nodeAddress:
     post:
       operationId: nodeAddress
-      summary: "[nodeAddress]"
+      summary: "[Miscellaneous-nodeAddress]"
       description: |
         The nodeAddress property provides the address of the node that a user is using. It is derived from the nodekey and used to sign consensus messages.
         

--- a/web3rpc/rpc-specs/paths/klay/miscellaneous/sha3.yaml
+++ b/web3rpc/rpc-specs/paths/klay/miscellaneous/sha3.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/sha3:
     post:
       operationId: sha3
-      summary: "[sha3]"
+      summary: "[Miscellaneous-sha3]"
       description: |
         Returns Keccak-256 (not the standardized SHA3-256) of the given data.
 

--- a/web3rpc/rpc-specs/paths/klay/transaction/call.yaml
+++ b/web3rpc/rpc-specs/paths/klay/transaction/call.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/call:
     post:
       operationId: call
-      summary: "[call]"
+      summary: "[Transaction-call]"
       tags:
         - klay
       description: |

--- a/web3rpc/rpc-specs/paths/klay/transaction/createAccessList.yaml
+++ b/web3rpc/rpc-specs/paths/klay/transaction/createAccessList.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/createAccessList:
     post:
       operationId: createAccessList
-      summary: "[createAccessList]"
+      summary: "[Transaction-createAccessList]"
       description: |
         This method creates an accessList based on a given Transaction. The accessList contains all storage slots and addresses read and written by the transaction, except for the sender account and the precompiles. This method uses the same transaction call object and blockNumberOrTag object as caver.rpc.klay.call. An accessList can be used to release stuck contracts that became inaccessible due to gas cost increases. Adding an accessList to your transaction does not necessary result in lower gas usage compared to a transaction without an access list.
 

--- a/web3rpc/rpc-specs/paths/klay/transaction/estimateComputationCost.yaml
+++ b/web3rpc/rpc-specs/paths/klay/transaction/estimateComputationCost.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/estimateComputationCost:
     post:
       operationId: estimateComputationCost
-      summary: "[estimateComputationCost]"
+      summary: "[Transaction-estimateComputationCost]"
       tags:
         - klay
       description: |

--- a/web3rpc/rpc-specs/paths/klay/transaction/estimateGas.yaml
+++ b/web3rpc/rpc-specs/paths/klay/transaction/estimateGas.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/estimateGas:
     post:
       operationId: estimateGas
-      summary: "[estimateGas]"
+      summary: "[Transaction-estimateGas]"
       tags:
         - klay
       description: |

--- a/web3rpc/rpc-specs/paths/klay/transaction/getDecodedAnchoringTransactionByHash.yaml
+++ b/web3rpc/rpc-specs/paths/klay/transaction/getDecodedAnchoringTransactionByHash.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getDecodedAnchoringTransactionByHash:
     post:
       operationId: getDecodedAnchoringTransactionByHash
-      summary: "[getDecodedAnchoringTransactionByHash]"
+      summary: "[Transaction-getDecodedAnchoringTransactionByHash]"
       description: |
         Returns the decoded anchored data in the transaction for the given transaction hash.
 

--- a/web3rpc/rpc-specs/paths/klay/transaction/getRawTransactionByBlockHashAndIndex.yaml
+++ b/web3rpc/rpc-specs/paths/klay/transaction/getRawTransactionByBlockHashAndIndex.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getRawTransactionByBlockHashAndIndex:
     post:
       operationId: getRawTransactionByBlockHashAndIndex
-      summary: "[getRawTransactionByBlockHashAndIndex]"
+      summary: "[Transaction-getRawTransactionByBlockHashAndIndex]"
       description: |
         GetRawTransactionByBlockHashAndIndex returns the bytes of the transaction for the given block hash and index.
         

--- a/web3rpc/rpc-specs/paths/klay/transaction/getRawTransactionByBlockNumberAndIndex.yaml
+++ b/web3rpc/rpc-specs/paths/klay/transaction/getRawTransactionByBlockNumberAndIndex.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getRawTransactionByBlockNumberAndIndex:
     post:
       operationId: getRawTransactionByBlockNumberAndIndex
-      summary: "[getRawTransactionByBlockNumberAndIndex]"
+      summary: "[Transaction-getRawTransactionByBlockNumberAndIndex]"
       tags:
         - klay
       description: |

--- a/web3rpc/rpc-specs/paths/klay/transaction/getRawTransactionByHash.yaml
+++ b/web3rpc/rpc-specs/paths/klay/transaction/getRawTransactionByHash.yaml
@@ -10,17 +10,17 @@ servers:
   - url: http://localhost:7151
 
 paths:
-  /eth/getRawTransactionByHash:
+  /klay/getRawTransactionByHash:
     post:
       operationId: getRawTransactionByHash
-      summary: "[getRawTransactionByHash]"
+      summary: "[Transaction-getRawTransactionByHash]"
       description: |
         GetRawTransactionByHash returns the bytes of the transaction for the given hash.
 
-        **JSONRPC:** `eth_getRawTransactionByHash`
+        **JSONRPC:** `klay_getRawTransactionByHash`
 
       tags:
-        - eth
+        - klay
 
       parameters:
         - name: hash
@@ -37,7 +37,7 @@ paths:
             schema:
               allOf:
                 - $ref: "../../../components/requests/JsonRpcRequest.yaml#/components/schemas/JsonRpcRequest"
-                - $ref: "#/components/schemas/EthGetRawTransactionByHashReq"
+                - $ref: "#/components/schemas/KlayGetRawTransactionByHashReq"
 
       responses:
         200:
@@ -47,28 +47,28 @@ paths:
               schema:
                 allOf:
                   - $ref: "../../../components/responses/JsonRpcResponse.yaml#/components/schemas/JsonRpcResponse"
-                  - $ref: "#/components/schemas/EthGetRawTransactionByHashResp"
+                  - $ref: "#/components/schemas/KlayGetRawTransactionByHashResp"
 
       x-codeSamples:
         - lang: "curl"
           label: "Curl"
           source:
-            $ref: "../../../code-samples/curl/eth/others/getRawTransactionByHash.sh"
+            $ref: "../../../code-samples/curl/klay/others/getRawTransactionByHash.sh"
         - lang: "java"
           label: "Java"
           source:
-            $ref: "../../../code-samples/java/src/main/java/opensdk/sdk/apis/eth/others/EthGetRawTransactionByHashExample.java"
+            $ref: "../../../code-samples/java/src/main/java/opensdk/sdk/apis/klay/others/KlayGetRawTransactionByHashExample.java"
         - lang: "javascript"
           label: "Javascript"
           source:
-            $ref: "../../../code-samples/javascript/eth/transaction/getRawTransactionByHash.js"
+            $ref: "../../../code-samples/javascript/klay/transaction/getRawTransactionByHash.js"
         - lang: "python"
           label: "Python"
           source:
             $ref: "../../../code-samples/python/klay/others/getRawTransactionByHash.py"
 components:
   schemas:
-    EthGetRawTransactionByHashReq:
+    KlayGetRawTransactionByHashReq:
       type: object
       required:
         - method
@@ -76,20 +76,17 @@ components:
       properties:
         method:
           type: string
-          default: "eth_getRawTransactionByHash"
+          default: 'klay_getRawTransactionByHash'
         params:
           type: array
-          description: Hex representation of a Keccak 256 hash
           items:
-            title: Hash
+            title: hash
             type: string
             format: hex
-          example:
-            [
-              "0x5bbcde52084defa9d1c7068a811363cc27a25c80d7e495180964673aa5f47687",
-            ]
+          description: Hex representation of a Keccak 256 hash
+          example:  ["0x29b6cd965c7d9a53a6f068da259dce1d3810ba79fff8eebac5d4da14754e67e6"]
 
-    EthGetRawTransactionByHashResp:
+    KlayGetRawTransactionByHashResp:
       type: object
       properties:
         result:

--- a/web3rpc/rpc-specs/paths/klay/transaction/getTransactionByBlockHashAndIndex.yaml
+++ b/web3rpc/rpc-specs/paths/klay/transaction/getTransactionByBlockHashAndIndex.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getTransactionByBlockHashAndIndex:
     post:
       operationId: getTransactionByBlockHashAndIndex
-      summary: "[getTransactionByBlockHashAndIndex]"
+      summary: "[Transaction-getTransactionByBlockHashAndIndex]"
       tags:
         - klay
       description: |

--- a/web3rpc/rpc-specs/paths/klay/transaction/getTransactionByBlockNumberAndIndex.yaml
+++ b/web3rpc/rpc-specs/paths/klay/transaction/getTransactionByBlockNumberAndIndex.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getTransactionByBlockNumberAndIndex:
     post:
       operationId: getTransactionByBlockNumberAndIndex
-      summary: "[getTransactionByBlockNumberAndIndex]"
+      summary: "[Transaction-getTransactionByBlockNumberAndIndex]"
       description: |
         Returns information about a transaction by block number and transaction index position. This API works only on RPC call, not on JavaScript console.
 

--- a/web3rpc/rpc-specs/paths/klay/transaction/getTransactionByHash.yaml
+++ b/web3rpc/rpc-specs/paths/klay/transaction/getTransactionByHash.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getTransactionByHash:
     post:
       operationId: getTransactionByHash
-      summary: "[getTransactionByHash]"
+      summary: "[Transaction-getTransactionByHash]"
       tags:
         - klay
       description: |

--- a/web3rpc/rpc-specs/paths/klay/transaction/getTransactionBySenderTxHash.yaml
+++ b/web3rpc/rpc-specs/paths/klay/transaction/getTransactionBySenderTxHash.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getTransactionBySenderTxHash:
     post:
       operationId: getTransactionBySenderTxHash
-      summary: "[getTransactionBySenderTxHash]"
+      summary: "[Transaction-getTransactionBySenderTxHash]"
       description: |
         Returns the information about a transaction requested by sender transaction hash. This API works only on RPC call, not on JavaScript console. Please note that this API returns correct result only if indexing feature is enabled by --sendertxhashindexing. This can be checked by call klay_isSenderTxHashIndexingEnabled.
 

--- a/web3rpc/rpc-specs/paths/klay/transaction/getTransactionReceipt.yaml
+++ b/web3rpc/rpc-specs/paths/klay/transaction/getTransactionReceipt.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getTransactionReceipt:
     post:
       operationId: getTransactionReceipt
-      summary: "[getTransactionReceipt]"
+      summary: "[Transaction-getTransactionReceipt]"
       description: |
         Returns the receipt of a transaction by transaction hash.
         

--- a/web3rpc/rpc-specs/paths/klay/transaction/getTransactionReceiptBySenderTxHash.yaml
+++ b/web3rpc/rpc-specs/paths/klay/transaction/getTransactionReceiptBySenderTxHash.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/getTransactionReceiptBySenderTxHash:
     post:
       operationId: getTransactionReceiptBySenderTxHash
-      summary: "[getTransactionReceiptBySenderTxHash]"
+      summary: "[Transaction-getTransactionReceiptBySenderTxHash]"
       tags:
         - klay
       description: |

--- a/web3rpc/rpc-specs/paths/klay/transaction/pendingTransactions.yaml
+++ b/web3rpc/rpc-specs/paths/klay/transaction/pendingTransactions.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/pendingTransactions:
     post:
       operationId: pendingTransactions
-      summary: "[pendingTransactions]"
+      summary: "[Transaction-pendingTransactions]"
       tags:
         - klay
       description: |

--- a/web3rpc/rpc-specs/paths/klay/transaction/resend.yaml
+++ b/web3rpc/rpc-specs/paths/klay/transaction/resend.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/resend:
     post:
       operationId: resend
-      summary: "[resend]"
+      summary: "[Transaction-resend]"
       description: |
         Resend accepts an existing transaction and a new gas price and limit. It will remove the given transaction from the pool and reinsert it with the new gas price and limit.
 

--- a/web3rpc/rpc-specs/paths/klay/transaction/sendRawTransaction.yaml
+++ b/web3rpc/rpc-specs/paths/klay/transaction/sendRawTransaction.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/sendRawTransaction:
     post:
       operationId: sendRawTransaction
-      summary: "[sendRawTransaction]"
+      summary: "[Transaction-sendRawTransaction]"
       description: |
         Creates a new message call transaction or a contract creation for signed transactions.
 

--- a/web3rpc/rpc-specs/paths/klay/transaction/sendTransaction.yaml
+++ b/web3rpc/rpc-specs/paths/klay/transaction/sendTransaction.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/sendTransaction:
     post:
       operationId: sendTransaction
-      summary: "[sendTransaction]"
+      summary: "[Transaction-sendTransaction]"
       description: |
         Constructs a transaction with given parameters, signs the transaction with a sender's private key and propagates the transaction to Klaytn network.
 

--- a/web3rpc/rpc-specs/paths/klay/transaction/sendTransactionAsFeePayer.yaml
+++ b/web3rpc/rpc-specs/paths/klay/transaction/sendTransactionAsFeePayer.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/sendTransactionAsFeePayer:
     post:
       operationId: sendTransactionAsFeePayer
-      summary: "[sendTransactionAsFeePayer]"
+      summary: "[Transaction-sendTransactionAsFeePayer]"
       description: |
         Constructs a transaction with given parameters, signs the transaction with a fee payer's private key and propagates the transaction to Klaytn network. This API supports only fee delegated type (including partial fee delegated type) transactions.
 

--- a/web3rpc/rpc-specs/paths/klay/transaction/signTransaction.yaml
+++ b/web3rpc/rpc-specs/paths/klay/transaction/signTransaction.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/signTransaction:
     post:
       operationId: signTransaction
-      summary: "[signTransaction]"
+      summary: "[Transaction-signTransaction]"
       description: |
         Constructs a transaction with given parameters and signs the transaction with a sender's private key. This method can be used either to generate a sender signature or to make a final raw transaction that is ready to submit to Klaytn network.
 

--- a/web3rpc/rpc-specs/paths/klay/transaction/signTransactionAsFeePayer.yaml
+++ b/web3rpc/rpc-specs/paths/klay/transaction/signTransactionAsFeePayer.yaml
@@ -13,7 +13,7 @@ paths:
   /klay/signTransactionAsFeePayer:
     post:
       operationId: signTransactionAsFeePayer
-      summary: "[signTransactionAsFeePayer]"
+      summary: "[Transaction-signTransactionAsFeePayer]"
       description: |
         Constructs a transaction with given parameters and signs the transaction with a fee payer's private key. This method can be used either to generate a fee payer signature or to make a final raw transaction that is ready to submit to Klaytn network. In case you just want to extract the fee-payer signature, simply take the feePayerSignatures from the result. Note that the raw transaction is not final if the sender's signature is not attached (that is, signatures in tx is empty).
 

--- a/web3rpc/sdk/client/javascript/scripts/admin/javascript-admin-generate.sh
+++ b/web3rpc/sdk/client/javascript/scripts/admin/javascript-admin-generate.sh
@@ -18,7 +18,7 @@ yarn install
 yarn link
 echo "${CURRENT_FILE_DIR}/openapi/admin"
 
-cd "${CURRENT_FILE_DIR}"/opensdk
+cd "${CURRENT_FILE_DIR}/opensdk"
 yarn link opensdk-javascript-admin
 
 

--- a/web3rpc/sdk/client/javascript/scripts/debug/javascript-debug-generate.sh
+++ b/web3rpc/sdk/client/javascript/scripts/debug/javascript-debug-generate.sh
@@ -18,6 +18,6 @@ yarn install
 yarn link 
 echo "${CURRENT_FILE_DIR}/openapi/debug"
 
-cd "${CURRENT_FILE_DIR}"/opensdk
+cd "${CURRENT_FILE_DIR}/opensdk"
 yarn link opensdk-javascript-debug
 

--- a/web3rpc/sdk/client/javascript/scripts/eth/javascript-eth-generate.sh
+++ b/web3rpc/sdk/client/javascript/scripts/eth/javascript-eth-generate.sh
@@ -18,7 +18,7 @@ yarn install
 yarn link 
 echo "${CURRENT_FILE_DIR}/openapi/eth"
 
-cd "${CURRENT_FILE_DIR}"/opensdk
+cd "${CURRENT_FILE_DIR}/opensdk"
 yarn link opensdk-javascript-eth
 
 

--- a/web3rpc/sdk/client/javascript/scripts/governance/javascript-governance-generate.sh
+++ b/web3rpc/sdk/client/javascript/scripts/governance/javascript-governance-generate.sh
@@ -18,7 +18,7 @@ yarn install
 yarn link
 echo "${CURRENT_FILE_DIR}/openapi/governance"
 
-cd "${CURRENT_FILE_DIR}"/opensdk
+cd "${CURRENT_FILE_DIR}/opensdk"
 yarn link opensdk-javascript-governance
 
 

--- a/web3rpc/sdk/client/javascript/scripts/klay/javascript-klay-generate.sh
+++ b/web3rpc/sdk/client/javascript/scripts/klay/javascript-klay-generate.sh
@@ -18,7 +18,7 @@ yarn install
 yarn link 
 echo "${CURRENT_FILE_DIR}/openapi/klay"
 
-cd "${CURRENT_FILE_DIR}"/opensdk
+cd "${CURRENT_FILE_DIR}/opensdk"
 yarn link opensdk-javascript-klay
 
 

--- a/web3rpc/sdk/client/javascript/scripts/mainbridge/javascript-mainbridge-generate.sh
+++ b/web3rpc/sdk/client/javascript/scripts/mainbridge/javascript-mainbridge-generate.sh
@@ -18,7 +18,7 @@ yarn install
 yarn link
 echo "${CURRENT_FILE_DIR}/openapi/mainbridge"
 
-cd "${CURRENT_FILE_DIR}"/opensdk
+cd "${CURRENT_FILE_DIR}/opensdk"
 yarn link opensdk-javascript-mainbridge
 
 

--- a/web3rpc/sdk/client/javascript/scripts/net/javascript-net-generate.sh
+++ b/web3rpc/sdk/client/javascript/scripts/net/javascript-net-generate.sh
@@ -18,6 +18,6 @@ yarn install
 yarn link 
 echo "${CURRENT_FILE_DIR}/openapi/net"
 
-cd "${CURRENT_FILE_DIR}"/opensdk
+cd "${CURRENT_FILE_DIR}/opensdk"
 yarn link opensdk-javascript-net
 

--- a/web3rpc/sdk/client/javascript/scripts/personal/javascript-personal-generate.sh
+++ b/web3rpc/sdk/client/javascript/scripts/personal/javascript-personal-generate.sh
@@ -18,7 +18,7 @@ yarn install
 yarn link
 echo "${CURRENT_FILE_DIR}/openapi/personal"
 
-cd "${CURRENT_FILE_DIR}"/opensdk
+cd "${CURRENT_FILE_DIR}/opensdk"
 yarn link opensdk-javascript-personal
 
 

--- a/web3rpc/sdk/client/javascript/scripts/subbridge/javascript-subbridge-generate.sh
+++ b/web3rpc/sdk/client/javascript/scripts/subbridge/javascript-subbridge-generate.sh
@@ -18,7 +18,7 @@ yarn install
 yarn link
 echo "${CURRENT_FILE_DIR}/openapi/subbridge"
 
-cd "${CURRENT_FILE_DIR}"/opensdk
+cd "${CURRENT_FILE_DIR}/opensdk"
 yarn link opensdk-javascript-subbridge
 
 

--- a/web3rpc/sdk/client/javascript/scripts/txpool/javascript-txpool-generate.sh
+++ b/web3rpc/sdk/client/javascript/scripts/txpool/javascript-txpool-generate.sh
@@ -18,6 +18,6 @@ yarn install
 yarn link 
 echo "${CURRENT_FILE_DIR}/openapi/txpool"
 
-cd "${CURRENT_FILE_DIR}"/opensdk
+cd "${CURRENT_FILE_DIR}/opensdk"
 yarn link opensdk-javascript-txpool
 


### PR DESCRIPTION
- root title is changed from web3klaytn to web3rpc in index.yaml
- summary in specification file for each APIs is categorized
- all the APIs is sorted in each categories because the redocly don't sort the APIs by each names.