### PR TITLE
update response of rpc klay_getAccount

### DIFF
--- a/web3rpc/codegen/src/main/kotlin/web3rpc/client/KlaytnJavaClientCodegen.kt
+++ b/web3rpc/codegen/src/main/kotlin/web3rpc/client/KlaytnJavaClientCodegen.kt
@@ -57,6 +57,7 @@ class KlaytnJavaClientCodegen : JavaClientCodegen {
             supportingFiles.add(SupportingFile("KlayGetAccountKey.java.mustache", modelFolder, "KlayGetAccountKey.java"))
             supportingFiles.add(SupportingFile("FilterOptions.java.mustache", modelFolder, "FilterOptions.java"))
             supportingFiles.add(SupportingFile("KlaytnTransactionTypes.java.mustache", modelFolder, "KlaytnTransactionTypes.java"))
+            supportingFiles.add(SupportingFile("KlayGetAccountAccountKey.java.mustache", modelFolder, "KlayGetAccountAccountKey.java"))
         } else if (artifactId.equals("web3rpc-eth")) {
             supportingFiles.add(SupportingFile("FilterOptions.java.mustache", modelFolder, "FilterOptions.java"))
         }

--- a/web3rpc/rpc-specs/paths/klay/account/getAccount.yaml
+++ b/web3rpc/rpc-specs/paths/klay/account/getAccount.yaml
@@ -116,12 +116,13 @@ components:
                   type: object
                   properties:
                     key:
-                      type: object
-                      properties:
-                        x:
-                          type: string
-                        y:
-                          type: string
+                      oneOf:
+                        - $ref: "#/components/schemas/AccountKeyLegacy"
+                        - $ref: "#/components/schemas/AccountKeyNil"
+                        - $ref: "#/components/schemas/AccountKeyPublic"
+                        - $ref: "#/components/schemas/AccountKeyFail"
+                        - $ref: "#/components/schemas/AccountKeyWeightedMultiSig"
+                        - $ref: "#/components/schemas/AccountKeyRoleBased"
                     keyType:
                       type: number
                 nonce:
@@ -142,3 +143,125 @@ components:
                 nonce: 11
               }
             }
+
+    AccountKeyNil:
+      title: AccountKeyNil
+      type: string
+
+    AccountKeyLegacy:
+      title: AccountKeyLegacy
+      type: object
+      required:
+        - key
+        - keyType
+      description: "AccountKeyLegacy is used for the account having an address derived from the corresponding key pair"
+      properties:
+        key:
+          type: object
+        keyType:
+          type: integer
+          description: "The type of AccountKeyLegacy. This must be 0x01."
+
+    AccountKeyPublic:
+      title: AccountKeyPublic
+      type: object
+      required:
+        - key
+        - keyType
+      description: "AccountKeyPublic is used for accounts having one public key."
+      properties:
+        key:
+          type: object
+          required:
+            - x
+            - y
+          description: "Key should be a compressed public key on S256 curve."
+          properties:
+            x:
+              type: string
+              format: 32-byte DATA
+              description: "The x coordinate of the public key."
+            y:
+              type: string
+              format: 32-byte DATA
+              description: "The y coordinate of the public key."
+        keyType:
+          type: integer
+          description: "The type of AccountKeyPublic. This must be 0x02."
+
+    AccountKeyFail:
+      title: AccountKeyFail
+      type: object
+      required:
+        - keyType
+        - key
+      description: "If an account has the key AccountKeyFail, the transaction validation process always fails. It can be used for smart contract accounts so that a transaction sent from the smart contract account always fails."
+      properties:
+        key:
+          type: object
+        keyType:
+          type: integer
+          description: "The type of AccountKeyFail. This must be 0x03."
+
+    AccountKeyWeightedMultiSig:
+      title: AccountKeyWeightedMultiSig
+      type: object
+      required:
+        - keyType
+        - Threshold
+        - WeightedPublicKeys
+      description: "AccountKeyWeightedMultiSig is an account key type containing a threshold and WeightedPublicKeys which contains a list consisting of a public key and its weight."
+      properties:
+        keyType:
+          type: integer
+          description: "The type of AccountKeyWeightedMultiSig. This must be 0x04."
+        Threshold:
+          type: integer
+          description: "Validation threshold. To be a valid transaction, the weight sum of signatures should be larger than or equal to the threshold."
+        WeightedPublicKeys:
+          type: array
+          description: "A list of weighted public keys. A weighted public key contains a compressed public key and its weight."
+          items:
+            type: object
+            required:
+              - PublicKey
+              - Weight
+            properties:
+              PublicKey:
+                type: object
+                required:
+                  - x
+                  - y
+                properties:
+                  x:
+                    type: string
+                    format: 32-byte DATA
+                    description: "The x coordinate of the public key."
+                  y:
+                    type: string
+                    format: 32-byte DATA
+                    description: "The y coordinate of the public key."
+              Weight:
+                type: integer
+
+    AccountKeyRoleBased:
+      title: AccountKeyRoleBased
+      type: object
+      required:
+        - keyType
+        - key
+      description: "AccountKeyRoleBased represents a role-based key"
+      properties:
+        key:
+          type: array
+          description: "A list of keys. A key can be any of AccountKeyNil, AccountKeyLegacy, AccountKeyPublic, AccountKeyFail, and AccountKeyWeightedMultiSig"
+          items:
+            anyOf:
+              - $ref: "#/components/schemas/AccountKeyNil"
+              - $ref: "#/components/schemas/AccountKeyLegacy"
+              - $ref: "#/components/schemas/AccountKeyPublic"
+              - $ref: "#/components/schemas/AccountKeyFail"
+              - $ref: "#/components/schemas/AccountKeyWeightedMultiSig"
+        keyType:
+          type: integer
+          description: "The type of AccountKeyRoleBased. This must be 0x05."

--- a/web3rpc/sdk/client/java/openapi-test/src/test/java/opensdk/sdk/apis/klay/account/KlayGetAccountApiTest.java
+++ b/web3rpc/sdk/client/java/openapi-test/src/test/java/opensdk/sdk/apis/klay/account/KlayGetAccountApiTest.java
@@ -21,7 +21,7 @@ public class KlayGetAccountApiTest {
     @DisplayName("RPC klay_getAccount")
     void whenRequestValid_ThenCall200ResponseReturns() throws IOException {
         KlayGetAccountResponse response = w3.klayGetAccount(
-            "0x1cbd3b2770909d4e10f157cabc84c7264073c9ec",
+            "0xd5e9ab70cca10f443491939dd896b580f7c72ea3",
             "latest").send();
 
         assertNotNull(response);

--- a/web3rpc/sdk/client/java/openapi-test/src/test/java/opensdk/sdk/apis/klay/transaction/KlaySendTransactionAsFeePayerTest.java
+++ b/web3rpc/sdk/client/java/openapi-test/src/test/java/opensdk/sdk/apis/klay/transaction/KlaySendTransactionAsFeePayerTest.java
@@ -30,7 +30,7 @@ public class KlaySendTransactionAsFeePayerTest {
         PersonalUtils.unlockAccount();
         String nonce = EthUtils.getNonce().getResult();
         KlaytnTransactionTypes tx = new KlaytnTransactionTypes();
-        tx.setTypeInt(new BigDecimal(17));
+        tx.setTypeInt(17);
         tx.setFrom(address);
         tx.setTo("0x44711E89b0c23845b5B2ed9D3716BA42b8a3e075");
         tx.setValue("0x1");

--- a/web3rpc/sdk/client/java/openapi-test/src/test/java/opensdk/sdk/apis/klay/transaction/KlaySignTransactionAsFeePayerTest.java
+++ b/web3rpc/sdk/client/java/openapi-test/src/test/java/opensdk/sdk/apis/klay/transaction/KlaySignTransactionAsFeePayerTest.java
@@ -29,7 +29,7 @@ public class KlaySignTransactionAsFeePayerTest {
         PersonalUtils.unlockAccount();
         String nonce = EthUtils.getNonce().getResult();
         KlaytnTransactionTypes type = new KlaytnTransactionTypes();
-        type.setTypeInt(new BigDecimal(17));
+        type.setTypeInt(17);
         type.setFrom(address);
         type.setTo("0x44711E89b0c23845b5B2ed9D3716BA42b8a3e075");
         type.setValue("0xf4");

--- a/web3rpc/sdk/client/java/template/KlayGetAccountAccountKey.java.mustache
+++ b/web3rpc/sdk/client/java/template/KlayGetAccountAccountKey.java.mustache
@@ -1,0 +1,67 @@
+package org.web3j.protocol.klaytn.core.method.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+@JsonPropertyOrder({"key", "keyType"})
+@JsonTypeName("KlayGetAccount_account_key")
+public class KlayGetAccountAccountKey {
+    public static final String JSON_PROPERTY_KEY = "key";
+    private Object key = null;
+    public static final String JSON_PROPERTY_KEY_TYPE = "keyType";
+    private BigDecimal keyType;
+
+    public KlayGetAccountAccountKey() {
+    }
+
+    public Object getKey() {
+        return this.key;
+    }
+
+    public void setKey(Object key) {
+        this.key = key;
+    }
+
+    public BigDecimal getKeyType() {
+        return this.keyType;
+    }
+
+    public void setKeyType(BigDecimal keyType) {
+        this.keyType = keyType;
+    }
+
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o != null && this.getClass() == o.getClass()) {
+            KlayGetAccountAccountKey klayGetAccountAccountKey = (KlayGetAccountAccountKey) o;
+            return Objects.equals(this.key, klayGetAccountAccountKey.key) && Objects.equals(this.keyType, klayGetAccountAccountKey.keyType);
+        } else {
+            return false;
+        }
+    }
+
+    public int hashCode() {
+        return Objects.hash(new Object[]{this.key, this.keyType});
+    }
+
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class KlayGetAccountAccountKey {\n");
+        sb.append("    key: ").append(this.toIndentedString(this.key)).append("\n");
+        sb.append("    keyType: ").append(this.toIndentedString(this.keyType)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    private String toIndentedString(Object o) {
+        return o == null ? "null" : o.toString().replace("\n", "\n    ");
+    }
+}


### PR DESCRIPTION
I fixed the deserialization issue in the case of an account belonging to the role-based type. In my commit, I did the following:
- Updated documentation for the klay_getAccount RPC section.
- Created a mustache file to override the object within the response returned by klay_getAccount RPC.
In case of returning a null key when the account is a multisig account, it appears that the key field in the response is an empty object.