### PR TITLE
Type enumeration and uint converter

### DIFF
--- a/ethers-ext/example/accountKey/AccountKeyLegacy_01_ValueTransfer.js
+++ b/ethers-ext/example/accountKey/AccountKeyLegacy_01_ValueTransfer.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet } = require("@klaytn/ethers-ext");
+const { Wallet, parseKlay } = require("@klaytn/ethers-ext");
 
 //
 // AccountKeyPublic Step 01 - value transfer
@@ -16,7 +16,7 @@ async function main() {
 
   let tx = {
       to: recieverAddr,
-      value: 100000000000,
+      value: parseKlay("1"),
       from: senderAddr,
     }; 
   

--- a/ethers-ext/example/accountKey/AccountKeyLegacy_02_ValueTransfer.js
+++ b/ethers-ext/example/accountKey/AccountKeyLegacy_02_ValueTransfer.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet } = require("@klaytn/ethers-ext");
+const { Wallet, parseKlay } = require("@klaytn/ethers-ext");
 
 //
 // AccountKeyPublic Step 02 - value transfer
@@ -16,7 +16,7 @@ async function main() {
 
   let tx = {
       to: recieverAddr,
-      value: 100000000000,
+      value: parseKlay("1"),
       from: senderAddr,
     }; 
   

--- a/ethers-ext/example/accountKey/AccountKeyPublic_01_accountUpdate.js
+++ b/ethers-ext/example/accountKey/AccountKeyPublic_01_accountUpdate.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
+const { Wallet, TxType, AccountKeyType } = require("@klaytn/ethers-ext");
 
 //
 // AccountKeyPublic Step 01 - account update
@@ -19,10 +19,10 @@ async function main() {
   let senderNewPub = new ethers.utils.SigningKey( senderNewPriv ).compressedPublicKey; 
 
   let tx = {
-        type: Klaytn.TxTypeAccountUpdate,
+        type: TxType.AccountUpdate,
         from: senderAddr,
         key: {
-            type: Klaytn.AccountKeyPublic,
+            type: AccountKeyType.Public,
             key: senderNewPub,
         }
     };

--- a/ethers-ext/example/accountKey/AccountKeyPublic_01_accountUpdate.js
+++ b/ethers-ext/example/accountKey/AccountKeyPublic_01_accountUpdate.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet } = require("@klaytn/ethers-ext");
+const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
 
 //
 // AccountKeyPublic Step 01 - account update
@@ -19,10 +19,10 @@ async function main() {
   let senderNewPub = new ethers.utils.SigningKey( senderNewPriv ).compressedPublicKey; 
 
   let tx = {
-        type: 0x20,   // TxTypeAccountUpdate
+        type: Klaytn.TxTypeAccountUpdate,
         from: senderAddr,
         key: {
-            type: 0x02,  // AccountKeyPublic
+            type: Klaytn.AccountKeyPublic,
             key: senderNewPub,
         }
     };

--- a/ethers-ext/example/accountKey/AccountKeyPublic_02_valueTransfer.js
+++ b/ethers-ext/example/accountKey/AccountKeyPublic_02_valueTransfer.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet } = require("@klaytn/ethers-ext");
+const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
 
 //
 // AccountKeyPublic Step 02 - value transfer
@@ -16,7 +16,7 @@ async function main() {
   const wallet = new Wallet( senderAddr, senderNewPriv, provider );
 
   let new_tx = {
-    type: 8,        // TxTypeValueTransfer
+    type: Klaytn.TxTypeValueTransfer
     to: recieverAddr,
     value: 100000000000,
     from: senderAddr,

--- a/ethers-ext/example/accountKey/AccountKeyPublic_02_valueTransfer.js
+++ b/ethers-ext/example/accountKey/AccountKeyPublic_02_valueTransfer.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, TxType } = require("@klaytn/ethers-ext");
+const { Wallet, TxType, parseKlay } = require("@klaytn/ethers-ext");
 
 //
 // AccountKeyPublic Step 02 - value transfer
@@ -18,7 +18,7 @@ async function main() {
   let new_tx = {
     type: TxType.ValueTransfer,
     to: recieverAddr,
-    value: 100000000000,
+    value: parseKlay("1"),
     from: senderAddr,
   }; 
 

--- a/ethers-ext/example/accountKey/AccountKeyPublic_02_valueTransfer.js
+++ b/ethers-ext/example/accountKey/AccountKeyPublic_02_valueTransfer.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
+const { Wallet, TxType } = require("@klaytn/ethers-ext");
 
 //
 // AccountKeyPublic Step 02 - value transfer
@@ -16,7 +16,7 @@ async function main() {
   const wallet = new Wallet( senderAddr, senderNewPriv, provider );
 
   let new_tx = {
-    type: Klaytn.TxTypeValueTransfer
+    type: TxType.ValueTransfer,
     to: recieverAddr,
     value: 100000000000,
     from: senderAddr,

--- a/ethers-ext/example/accountKey/AccountKeyPublic_03_valueTransfer.js
+++ b/ethers-ext/example/accountKey/AccountKeyPublic_03_valueTransfer.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
+const { Wallet, TxType } = require("@klaytn/ethers-ext");
 
 //
 // AccountKeyPublic Step 03 - value transfer
@@ -16,7 +16,7 @@ async function main() {
   const wallet = new Wallet( senderAddr, senderNewPriv, provider );
 
   let tx = {
-    type: Klaytn.TxTypeValueTransfer,
+    type: TxType.ValueTransfer,
     to: recieverAddr,
     value: 100000000000,
     from: senderAddr,

--- a/ethers-ext/example/accountKey/AccountKeyPublic_03_valueTransfer.js
+++ b/ethers-ext/example/accountKey/AccountKeyPublic_03_valueTransfer.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet } = require("@klaytn/ethers-ext");
+const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
 
 //
 // AccountKeyPublic Step 03 - value transfer
@@ -16,7 +16,7 @@ async function main() {
   const wallet = new Wallet( senderAddr, senderNewPriv, provider );
 
   let tx = {
-    type: 8,        // TxTypeValueTransfer
+    type: Klaytn.TxTypeValueTransfer,
     to: recieverAddr,
     value: 100000000000,
     from: senderAddr,

--- a/ethers-ext/example/accountKey/AccountKeyPublic_03_valueTransfer.js
+++ b/ethers-ext/example/accountKey/AccountKeyPublic_03_valueTransfer.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, TxType } = require("@klaytn/ethers-ext");
+const { Wallet, TxType, parseKlay } = require("@klaytn/ethers-ext");
 
 //
 // AccountKeyPublic Step 03 - value transfer
@@ -18,7 +18,7 @@ async function main() {
   let tx = {
     type: TxType.ValueTransfer,
     to: recieverAddr,
-    value: 100000000000,
+    value: parseKlay("1"),
     from: senderAddr,
   }; 
 

--- a/ethers-ext/example/accountKey/AccountKeyRoleBased_01_accountUpdate.js
+++ b/ethers-ext/example/accountKey/AccountKeyRoleBased_01_accountUpdate.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet } = require("@klaytn/ethers-ext");
+const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
 
 // 
 // AccountKeyRoleBased Step 01 - account update
@@ -29,27 +29,27 @@ async function main() {
   console.log('3', pub3);
 
   let tx = {
-        type: 0x20,   // TxTypeAccountUpdate
+        type: Klaytn.TxTypeAccountUpdate, 
         from: senderAddr,
         gasLimit: 1000000, 
         key: {
-          type: 0x05,   // AccountKeyRoleBased
+          type: Klaytn.AccountKeyRoleBased,
           keys: [
             // RoleTransaction
             {
-              type: 0x02,  
+              type: Klaytn.AccountKeyPublic,  
               key: pub1,            
             },
             
             // RoleAccountUpdate
             {
-              type: 0x02,  
+              type: Klaytn.AccountKeyPublic,  
               key: pub2,
             },
             
             // RoleFeePayer
             {
-              type: 0x02,  
+              type: Klaytn.AccountKeyPublic,  
               key: pub3,
             } 
           ]

--- a/ethers-ext/example/accountKey/AccountKeyRoleBased_01_accountUpdate.js
+++ b/ethers-ext/example/accountKey/AccountKeyRoleBased_01_accountUpdate.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
+const { Wallet, TxType, AccountKeyType } = require("@klaytn/ethers-ext");
 
 // 
 // AccountKeyRoleBased Step 01 - account update
@@ -29,27 +29,27 @@ async function main() {
   console.log('3', pub3);
 
   let tx = {
-        type: Klaytn.TxTypeAccountUpdate, 
+        type: TxType.AccountUpdate, 
         from: senderAddr,
         gasLimit: 1000000, 
         key: {
-          type: Klaytn.AccountKeyRoleBased,
+          type: AccountKeyType.RoleBased,
           keys: [
             // RoleTransaction
             {
-              type: Klaytn.AccountKeyPublic,  
+              type: AccountKeyType.Public,  
               key: pub1,            
             },
             
             // RoleAccountUpdate
             {
-              type: Klaytn.AccountKeyPublic,  
+              type: AccountKeyType.Public,  
               key: pub2,
             },
             
             // RoleFeePayer
             {
-              type: Klaytn.AccountKeyPublic,  
+              type: AccountKeyType.Public,  
               key: pub3,
             } 
           ]

--- a/ethers-ext/example/accountKey/AccountKeyRoleBased_02_valueTransfer.js
+++ b/ethers-ext/example/accountKey/AccountKeyRoleBased_02_valueTransfer.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, TxType } = require("@klaytn/ethers-ext");
+const { Wallet, TxType, parseKlay } = require("@klaytn/ethers-ext");
 
 // 
 // AccountKeyRoleBased Step 02 - value transfer
@@ -21,7 +21,7 @@ async function main() {
     type: TxType.ValueTransfer,
     gasLimit: 100000, 
     to: recieverAddr,
-    value: 100000000000,
+    value: parseKlay("1"),
     from: senderAddr,
   }; 
 

--- a/ethers-ext/example/accountKey/AccountKeyRoleBased_02_valueTransfer.js
+++ b/ethers-ext/example/accountKey/AccountKeyRoleBased_02_valueTransfer.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
+const { Wallet, TxType } = require("@klaytn/ethers-ext");
 
 // 
 // AccountKeyRoleBased Step 02 - value transfer
@@ -18,7 +18,7 @@ const senderRoleTransactionPriv = '0xc9668ccd35fc20587aa37a48838b48ccc13cf14dd74
 async function main() {
 
   let tx = {
-    type: Klaytn.TxTypeValueTransfer,
+    type: TxType.ValueTransfer,
     gasLimit: 100000, 
     to: recieverAddr,
     value: 100000000000,

--- a/ethers-ext/example/accountKey/AccountKeyRoleBased_02_valueTransfer.js
+++ b/ethers-ext/example/accountKey/AccountKeyRoleBased_02_valueTransfer.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet } = require("@klaytn/ethers-ext");
+const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
 
 // 
 // AccountKeyRoleBased Step 02 - value transfer
@@ -18,7 +18,7 @@ const senderRoleTransactionPriv = '0xc9668ccd35fc20587aa37a48838b48ccc13cf14dd74
 async function main() {
 
   let tx = {
-    type: 8,
+    type: Klaytn.TxTypeValueTransfer,
     gasLimit: 100000, 
     to: recieverAddr,
     value: 100000000000,

--- a/ethers-ext/example/accountKey/AccountKeyWeightedMultiSig_01_accountUpdate.js
+++ b/ethers-ext/example/accountKey/AccountKeyWeightedMultiSig_01_accountUpdate.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
+const { Wallet, TxType, AccountKeyType } = require("@klaytn/ethers-ext");
 
 // 
 // AccountKeyWeightedMultiSig Step 01 - account update
@@ -25,11 +25,11 @@ async function main() {
   let senderNewPub3 = new ethers.utils.SigningKey( senderNewPriv3 ).compressedPublicKey;
 
   let tx = {
-        type: Klaytn.TxTypeAccountUpdate, 
+        type: TxType.AccountUpdate, 
         from: senderAddr,
         gasLimit: 100000, 
         key: {
-            type: Klaytn.AccountKeyWeightedMultiSig,
+            type: AccountKeyType.WeightedMultiSig,
             keys: [
               2,   // threshold
               [

--- a/ethers-ext/example/accountKey/AccountKeyWeightedMultiSig_01_accountUpdate.js
+++ b/ethers-ext/example/accountKey/AccountKeyWeightedMultiSig_01_accountUpdate.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet } = require("@klaytn/ethers-ext");
+const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
 
 // 
 // AccountKeyWeightedMultiSig Step 01 - account update
@@ -25,11 +25,11 @@ async function main() {
   let senderNewPub3 = new ethers.utils.SigningKey( senderNewPriv3 ).compressedPublicKey;
 
   let tx = {
-        type: 0x20,   // TxTypeAccountUpdate
+        type: Klaytn.TxTypeAccountUpdate, 
         from: senderAddr,
         gasLimit: 100000, 
         key: {
-            type: 0x04,   // AccountKeyWeightedMultiSig
+            type: Klaytn.AccountKeyWeightedMultiSig,
             keys: [
               2,   // threshold
               [

--- a/ethers-ext/example/accountKey/AccountKeyWeightedMultiSig_02_valueTransfer.js
+++ b/ethers-ext/example/accountKey/AccountKeyWeightedMultiSig_02_valueTransfer.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
+const { Wallet, TxType } = require("@klaytn/ethers-ext");
 
 // 
 // AccountKeyWeightedMultiSig Step 02 - value transfer
@@ -20,7 +20,7 @@ const senderNewPriv3 = '0xc9668ccd35fc20587aa37a48838b48ccc13cf14dd74c8999dd6a48
 async function main() {
 
   let tx = {
-    type: Klaytn.TxTypeValueTransfer,
+    type: TxType.ValueTransfer,
     gasLimit: 100000, 
     to: recieverAddr,
     value: 100000000000,

--- a/ethers-ext/example/accountKey/AccountKeyWeightedMultiSig_02_valueTransfer.js
+++ b/ethers-ext/example/accountKey/AccountKeyWeightedMultiSig_02_valueTransfer.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, TxType } = require("@klaytn/ethers-ext");
+const { Wallet, TxType, parseKlay } = require("@klaytn/ethers-ext");
 
 // 
 // AccountKeyWeightedMultiSig Step 02 - value transfer
@@ -23,7 +23,7 @@ async function main() {
     type: TxType.ValueTransfer,
     gasLimit: 100000, 
     to: recieverAddr,
-    value: 100000000000,
+    value: parseKlay("1"),
     from: senderAddr,
   }; 
 

--- a/ethers-ext/example/accountKey/AccountKeyWeightedMultiSig_02_valueTransfer.js
+++ b/ethers-ext/example/accountKey/AccountKeyWeightedMultiSig_02_valueTransfer.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet } = require("@klaytn/ethers-ext");
+const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
 
 // 
 // AccountKeyWeightedMultiSig Step 02 - value transfer
@@ -20,7 +20,7 @@ const senderNewPriv3 = '0xc9668ccd35fc20587aa37a48838b48ccc13cf14dd74c8999dd6a48
 async function main() {
 
   let tx = {
-    type: 8,
+    type: Klaytn.TxTypeValueTransfer,
     gasLimit: 100000, 
     to: recieverAddr,
     value: 100000000000,

--- a/ethers-ext/example/accountStore/accountStore.js
+++ b/ethers-ext/example/accountStore/accountStore.js
@@ -22,9 +22,9 @@ async function main() {
   console.log( accountStore.getAccountInfos() );
 
   console.log( accountStore.getType('0xA2a8854b1802D8Cd5De631E690817c253d6a9153') );  // 1
-  console.log( accountStore.getType('0xCb0eb737dfda52756495A5e08A9b37AAB3b271dA') );  // 2
-  console.log( accountStore.getType('0xe15Cd70A41dfb05e7214004d7D054801b2a2f06b') );  // 4
-  console.log( accountStore.getType('0x82c6a8d94993d49cfd0c1d30f0f8caa65782cc7e') );  // 5
+  console.log( accountStore.getType('0xCb0eb737dfda52756495A5e08A9b37AAB3b271dA') );  // 1
+  console.log( accountStore.getType('0xe15Cd70A41dfb05e7214004d7D054801b2a2f06b') );  // 2
+  console.log( accountStore.getType('0x82c6a8d94993d49cfd0c1d30f0f8caa65782cc7e') );  // 4
   console.log( accountStore.getType('0x5bd2fb3c21564c023a4a735935a2b7a238c4ccea') );  // 5
 
   console.log( accountStore.getAccountInfo('0xA2a8854b1802D8Cd5De631E690817c253d6a9153') ); 

--- a/ethers-ext/example/accountStore/accountStore.js
+++ b/ethers-ext/example/accountStore/accountStore.js
@@ -1,14 +1,9 @@
 const ethers = require("ethers");
 const { Accounts, AccountStore } = require("@klaytn/ethers-ext");
-const fs = require('fs');
 
 //
 // AccountStore example
 // 
-
-const priv = fs.readFileSync('./example/key.priv', 'utf8') 
-const priv2 = fs.readFileSync('./example/key2.priv', 'utf8') 
-const priv3 = fs.readFileSync('./example/key3.priv', 'utf8') 
 
 async function main() {
   const provider = new ethers.providers.JsonRpcProvider('https://public-en-baobab.klaytn.net');
@@ -16,23 +11,23 @@ async function main() {
   let accountStore = new AccountStore(); 
 
   await accountStore.refresh( provider, [
-    [priv],   // '0x3208ca99480f82bfe240ca6bc06110cd12bb6366'
-    ['0x1173d5dc7b5e1e07d857d74e962b6ed7d4234a92', priv],
-    [priv2],  // '0xe81d480b3e90f11f82b35f3fED1400dcc79cf1B5' 
-    ['0x218e49acd85a1eb3e840eac0c9668e188c452e0c', priv],
-    ['0x218e49acd85a1eb3e840eac0c9668e188c452e0c', priv2],
-    ['0x218e49acd85a1eb3e840eac0c9668e188c452e0c', priv3],
-    ['0x9b4284806060423079e612203c22e8cb48b9870e', priv3]
+    ['0xA2a8854b1802D8Cd5De631E690817c253d6a9153', '0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8'],
+    ['0xCb0eb737dfda52756495A5e08A9b37AAB3b271dA', '0x9435261ed483b6efa3886d6ad9f64c12078a0e28d8d80715c773e16fc000cff4'],
+    ['0xe15Cd70A41dfb05e7214004d7D054801b2a2f06b', '0xc9668ccd35fc20587aa37a48838b48ccc13cf14dd74c8999dd6a480212d5f7ac'],
+    ['0xe15cd70a41dfb05e7214004d7d054801b2a2f06b', '0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8'],
+    ['0x82c6a8d94993d49cfd0c1d30f0f8caa65782cc7e', '0xa32c30608667d43be2d652bede413f12a649dd1be93440878e7f712d51a6768a'],
+    ['0x5bd2fb3c21564c023a4a735935a2b7a238c4ccea', '0x9ba8cb8f60044058a9e6f815c5c42d3a216f47044c61a1750b6d29ddc7f34bda']
   ]); 
 
   console.log( accountStore.getAccountInfos() );
 
-  console.log( accountStore.getType('0x3208ca99480f82bfe240ca6bc06110cd12bb6366') );  // 1
-  console.log( accountStore.getType('0x1173d5dc7b5e1e07d857d74e962b6ed7d4234a92') );  // 2
-  console.log( accountStore.getType('0x218e49acd85a1eb3e840eac0c9668e188c452e0c') );  // 4
-  console.log( accountStore.getType('0x9b4284806060423079e612203c22e8cb48b9870e') );  // 5
+  console.log( accountStore.getType('0xA2a8854b1802D8Cd5De631E690817c253d6a9153') );  // 1
+  console.log( accountStore.getType('0xCb0eb737dfda52756495A5e08A9b37AAB3b271dA') );  // 2
+  console.log( accountStore.getType('0xe15Cd70A41dfb05e7214004d7D054801b2a2f06b') );  // 4
+  console.log( accountStore.getType('0x82c6a8d94993d49cfd0c1d30f0f8caa65782cc7e') );  // 5
+  console.log( accountStore.getType('0x5bd2fb3c21564c023a4a735935a2b7a238c4ccea') );  // 5
 
-  console.log( accountStore.getAccountInfo('0x3208ca99480f82bfe240ca6bc06110cd12bb6366') ); 
+  console.log( accountStore.getAccountInfo('0xA2a8854b1802D8Cd5De631E690817c253d6a9153') ); 
 }
 
 main();

--- a/ethers-ext/example/accountStore/accountStore.js
+++ b/ethers-ext/example/accountStore/accountStore.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Accounts, AccountStore } = require("@klaytn/ethers-ext");
+const { AccountStore } = require("@klaytn/ethers-ext");
 
 //
 // AccountStore example

--- a/ethers-ext/example/accountStore/accountStore2.js
+++ b/ethers-ext/example/accountStore/accountStore2.js
@@ -1,0 +1,35 @@
+const ethers = require("ethers");
+const { Wallet, AccountStore } = require("@klaytn/ethers-ext");
+
+//
+// AccountStore example
+// 
+
+async function main() {
+  const provider = new ethers.providers.JsonRpcProvider('https://public-en-baobab.klaytn.net');
+
+  const wallet = [
+    new Wallet('0xA2a8854b1802D8Cd5De631E690817c253d6a9153', '0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8', provider),
+    new Wallet('0xCb0eb737dfda52756495A5e08A9b37AAB3b271dA', '0x9435261ed483b6efa3886d6ad9f64c12078a0e28d8d80715c773e16fc000cff4', provider),
+    new Wallet('0xe15Cd70A41dfb05e7214004d7D054801b2a2f06b', '0xc9668ccd35fc20587aa37a48838b48ccc13cf14dd74c8999dd6a480212d5f7ac', provider),
+    new Wallet('0xe15cd70a41dfb05e7214004d7d054801b2a2f06b', '0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8', provider),
+    new Wallet('0x82c6a8d94993d49cfd0c1d30f0f8caa65782cc7e', '0xa32c30608667d43be2d652bede413f12a649dd1be93440878e7f712d51a6768a', provider),
+    new Wallet('0x5bd2fb3c21564c023a4a735935a2b7a238c4ccea', '0x9ba8cb8f60044058a9e6f815c5c42d3a216f47044c61a1750b6d29ddc7f34bda', provider) 
+  ];
+  
+  let accountStore = new AccountStore(); 
+
+  await accountStore.refresh( provider, wallet); 
+
+  console.log( accountStore.getAccountInfos() );
+
+  console.log( accountStore.getType('0xA2a8854b1802D8Cd5De631E690817c253d6a9153') );  // 1
+  console.log( accountStore.getType('0xCb0eb737dfda52756495A5e08A9b37AAB3b271dA') );  // 1
+  console.log( accountStore.getType('0xe15Cd70A41dfb05e7214004d7D054801b2a2f06b') );  // 2
+  console.log( accountStore.getType('0x82c6a8d94993d49cfd0c1d30f0f8caa65782cc7e') );  // 4
+  console.log( accountStore.getType('0x5bd2fb3c21564c023a4a735935a2b7a238c4ccea') );  // 5
+
+  console.log( accountStore.getAccountInfo('0xA2a8854b1802D8Cd5De631E690817c253d6a9153') ); 
+}
+
+main();

--- a/ethers-ext/example/accountStore/accounts.js
+++ b/ethers-ext/example/accountStore/accounts.js
@@ -1,40 +1,42 @@
 const ethers = require("ethers");
 const { Accounts } = require("@klaytn/ethers-ext");
-const fs = require('fs');
 
 //
 // Accounts example
 // 
 
-const priv = fs.readFileSync('./example/key.priv', 'utf8') 
-const priv2 = fs.readFileSync('./example/key2.priv', 'utf8') 
-const priv3 = fs.readFileSync('./example/key3.priv', 'utf8') 
-
 async function main() {
-  let accounts = new Accounts([
-    [priv],
-    ['0x1173d5dc7b5e1e07d857d74e962b6ed7d4234a92', priv], 
-    ['0xe81d480b3e90f11f82b35f3fED1400dcc79cf1B5', priv2]
+  const provider = new ethers.providers.JsonRpcProvider('https://public-en-baobab.klaytn.net');
+
+  let accounts = new Accounts( provider, [
+    ['0xA2a8854b1802D8Cd5De631E690817c253d6a9153', '0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8'],
+    ['0xCb0eb737dfda52756495A5e08A9b37AAB3b271dA', '0x9435261ed483b6efa3886d6ad9f64c12078a0e28d8d80715c773e16fc000cff4'],
+    ['0xe15Cd70A41dfb05e7214004d7D054801b2a2f06b', '0xc9668ccd35fc20587aa37a48838b48ccc13cf14dd74c8999dd6a480212d5f7ac'],
+    ['0xe15cd70a41dfb05e7214004d7d054801b2a2f06b', '0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8'],
+    ['0x82c6a8d94993d49cfd0c1d30f0f8caa65782cc7e', '0xa32c30608667d43be2d652bede413f12a649dd1be93440878e7f712d51a6768a']
   ]); 
-  
-  console.log( accounts );
 
-  console.log( await accounts.add( ['0x669b3C8DC78FC785792469dD109314b36879EaFc', priv3] )) ; // true 
-  console.log( await accounts.add( ['0x669b3C8DC78FC785792469dD109314b36879EaFc', priv3] )) ; // false (already exist)
-
-  console.log( accounts );
-
-  console.log( await accounts.remove( ['0x669b3C8DC78FC785792469dD109314b36879EaFc', priv3] )) ; // true 
-  console.log( await accounts.remove( ['0x669b3C8DC78FC785792469dD109314b36879EaFc', priv3] )) ; // false (already delete)
+  console.log( await accounts.add( 
+    ['0x5bd2fb3c21564c023a4a735935a2b7a238c4ccea', '0x9ba8cb8f60044058a9e6f815c5c42d3a216f47044c61a1750b6d29ddc7f34bda'])) ; // true 
+  console.log( await accounts.add( 
+    ['0x5bd2fb3c21564c023a4a735935a2b7a238c4ccea', '0x9ba8cb8f60044058a9e6f815c5c42d3a216f47044c61a1750b6d29ddc7f34bda'])) ; // false (already exist)
 
   console.log( accounts );
 
+  console.log( await accounts.remove( 
+    ['0x5bd2fb3c21564c023a4a735935a2b7a238c4ccea', '0x9ba8cb8f60044058a9e6f815c5c42d3a216f47044c61a1750b6d29ddc7f34bda'])) ; // true
+  console.log( await accounts.remove( 
+    ['0x5bd2fb3c21564c023a4a735935a2b7a238c4ccea', '0x9ba8cb8f60044058a9e6f815c5c42d3a216f47044c61a1750b6d29ddc7f34bda'])) ; // false (already exist)
+  console.log( await accounts.add( 
+    ['0x5bd2fb3c21564c023a4a735935a2b7a238c4ccea', '0x9ba8cb8f60044058a9e6f815c5c42d3a216f47044c61a1750b6d29ddc7f34bda'])) ; // true
+
+  let priv = '0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8'; 
   console.log( accounts.accountByKey( priv ).length ) ; // 2 
-  console.log( accounts.accountByKey( priv )[0].getAddress() ) ; // '0x3208ca99480f82bfe240ca6bc06110cd12bb6366'
-  console.log( accounts.accountByKey( priv )[1].getAddress() ) ; // '0x1173d5dc7b5e1e07d857d74e962b6ed7d4234a92'
+  console.log( accounts.accountByKey( priv )[0].getAddress() ) ; // '0xA2a8854b1802D8Cd5De631E690817c253d6a9153'
+  console.log( accounts.accountByKey( priv )[1].getAddress() ) ; // '0xe15cd70a41dfb05e7214004d7d054801b2a2f06b'
 
-  let wallets = await accounts.accountByAddress( '0x3208ca99480f82bfe240ca6bc06110cd12bb6366' );
-  console.log( wallets[0].getAddress() );  // '0x3208ca99480f82bfe240ca6bc06110cd12bb6366'
+  let wallets = await accounts.accountByAddress( '0xe15cd70a41dfb05e7214004d7d054801b2a2f06b' );
+  console.log( wallets[0].getAddress() );  // '0xe15cd70a41dfb05e7214004d7d054801b2a2f06b'
 }
 
 main();

--- a/ethers-ext/example/accountStore/accounts2.js
+++ b/ethers-ext/example/accountStore/accounts2.js
@@ -1,0 +1,42 @@
+const ethers = require("ethers");
+const { Wallet, Accounts } = require("@klaytn/ethers-ext");
+
+//
+// Accounts example
+// 
+
+async function main() {
+  const provider = new ethers.providers.JsonRpcProvider('https://public-en-baobab.klaytn.net');
+
+  let accounts = new Accounts( provider, [
+    ['0xA2a8854b1802D8Cd5De631E690817c253d6a9153', '0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8'],
+    new Wallet('0xCb0eb737dfda52756495A5e08A9b37AAB3b271dA', '0x9435261ed483b6efa3886d6ad9f64c12078a0e28d8d80715c773e16fc000cff4', provider),
+    ['0xe15Cd70A41dfb05e7214004d7D054801b2a2f06b', '0xc9668ccd35fc20587aa37a48838b48ccc13cf14dd74c8999dd6a480212d5f7ac'],
+    new Wallet('0xe15cd70a41dfb05e7214004d7d054801b2a2f06b', '0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8', provider),
+    ['0x82c6a8d94993d49cfd0c1d30f0f8caa65782cc7e', '0xa32c30608667d43be2d652bede413f12a649dd1be93440878e7f712d51a6768a']
+  ]); 
+
+  console.log( await accounts.add( 
+    ['0x5bd2fb3c21564c023a4a735935a2b7a238c4ccea', '0x9ba8cb8f60044058a9e6f815c5c42d3a216f47044c61a1750b6d29ddc7f34bda'])) ; // true 
+  console.log( await accounts.add( 
+    ['0x5bd2fb3c21564c023a4a735935a2b7a238c4ccea', '0x9ba8cb8f60044058a9e6f815c5c42d3a216f47044c61a1750b6d29ddc7f34bda'])) ; // false (already exist)
+
+  console.log( accounts );
+
+  console.log( await accounts.remove( 
+    ['0x5bd2fb3c21564c023a4a735935a2b7a238c4ccea', '0x9ba8cb8f60044058a9e6f815c5c42d3a216f47044c61a1750b6d29ddc7f34bda'])) ; // true
+  console.log( await accounts.remove( 
+    ['0x5bd2fb3c21564c023a4a735935a2b7a238c4ccea', '0x9ba8cb8f60044058a9e6f815c5c42d3a216f47044c61a1750b6d29ddc7f34bda'])) ; // false (already exist)
+  console.log( await accounts.add( 
+    ['0x5bd2fb3c21564c023a4a735935a2b7a238c4ccea', '0x9ba8cb8f60044058a9e6f815c5c42d3a216f47044c61a1750b6d29ddc7f34bda'])) ; // true
+
+  let priv = '0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8'; 
+  console.log( accounts.accountByKey( priv ).length ) ; // 2 
+  console.log( accounts.accountByKey( priv )[0].getAddress() ) ; // '0xA2a8854b1802D8Cd5De631E690817c253d6a9153'
+  console.log( accounts.accountByKey( priv )[1].getAddress() ) ; // '0xe15cd70a41dfb05e7214004d7d054801b2a2f06b'
+
+  let wallets = await accounts.accountByAddress( '0xe15cd70a41dfb05e7214004d7d054801b2a2f06b' );
+  console.log( wallets[0].getAddress() );  // '0xe15cd70a41dfb05e7214004d7d054801b2a2f06b'
+}
+
+main();

--- a/ethers-ext/example/accountStore/accounts2.js
+++ b/ethers-ext/example/accountStore/accounts2.js
@@ -9,11 +9,11 @@ async function main() {
   const provider = new ethers.providers.JsonRpcProvider('https://public-en-baobab.klaytn.net');
 
   let accounts = new Accounts( provider, [
-    ['0xA2a8854b1802D8Cd5De631E690817c253d6a9153', '0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8'],
+    new Wallet('0xA2a8854b1802D8Cd5De631E690817c253d6a9153', '0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8', provider),
     new Wallet('0xCb0eb737dfda52756495A5e08A9b37AAB3b271dA', '0x9435261ed483b6efa3886d6ad9f64c12078a0e28d8d80715c773e16fc000cff4', provider),
-    ['0xe15Cd70A41dfb05e7214004d7D054801b2a2f06b', '0xc9668ccd35fc20587aa37a48838b48ccc13cf14dd74c8999dd6a480212d5f7ac'],
+    new Wallet('0xe15Cd70A41dfb05e7214004d7D054801b2a2f06b', '0xc9668ccd35fc20587aa37a48838b48ccc13cf14dd74c8999dd6a480212d5f7ac', provider),
     new Wallet('0xe15cd70a41dfb05e7214004d7d054801b2a2f06b', '0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8', provider),
-    ['0x82c6a8d94993d49cfd0c1d30f0f8caa65782cc7e', '0xa32c30608667d43be2d652bede413f12a649dd1be93440878e7f712d51a6768a']
+    new Wallet('0x82c6a8d94993d49cfd0c1d30f0f8caa65782cc7e', '0xa32c30608667d43be2d652bede413f12a649dd1be93440878e7f712d51a6768a', provider)
   ]); 
 
   console.log( await accounts.add( 

--- a/ethers-ext/example/smartContract/deploy_with_FeeDelegation.js
+++ b/ethers-ext/example/smartContract/deploy_with_FeeDelegation.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet } = require("@klaytn/ethers-ext");
+const { Wallet, TxType } = require("@klaytn/ethers-ext");
 
 // We refer the example from ethers
 // https://docs.ethers.org/v5/api/contract/example/
@@ -33,7 +33,7 @@ async function main() {
     // }
 
     const tx = {
-        type: 0x29,
+        type: TxType.FeeDelegatedSmartContractDeploy,
         to:    "0x0000000000000000000000000000000000000000",
         value: 0,  
         from: senderAddr,

--- a/ethers-ext/example/smartContract/write_with_feeDelegation.js
+++ b/ethers-ext/example/smartContract/write_with_feeDelegation.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet } = require("@klaytn/ethers-ext");
+const { Wallet, TxType } = require("@klaytn/ethers-ext");
 
 // We refer the example from ethers
 // https://docs.ethers.org/v5/api/contract/example/
@@ -42,7 +42,7 @@ async function main() {
     // }
 
     const feeDelegatedTx = {
-        type: 0x31,
+        type: TxType.FeeDelegatedSmartContractExecution,
         to: tx.to,
         value: 0,  
         from: tx.from,

--- a/ethers-ext/example/transactions/Basic_08_TxTypeValueTransfer.js
+++ b/ethers-ext/example/transactions/Basic_08_TxTypeValueTransfer.js
@@ -1,11 +1,9 @@
 const ethers = require("ethers");
-const { Wallet } = require("@klaytn/ethers-ext");
+const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
 
 //
 // TxTypeValueTransfer
 // https://docs.klaytn.foundation/content/klaytn/design/transactions/basic#txtypevaluetransfer
-// 
-//   type: Must be 0x08,
 // 
 const recieverAddr = '0xc40b6909eb7085590e1c26cb3becc25368e249e9' 
 const senderAddr = '0xa2a8854b1802d8cd5de631e690817c253d6a9153' 
@@ -16,7 +14,7 @@ async function main() {
   const wallet = new Wallet(senderPriv, provider);
 
   let tx = {
-      type: 8,
+      type: Klaytn.TxTypeValueTransfer,
       to: recieverAddr,
       value: 100000000000,
       from: senderAddr,

--- a/ethers-ext/example/transactions/Basic_08_TxTypeValueTransfer.js
+++ b/ethers-ext/example/transactions/Basic_08_TxTypeValueTransfer.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, TxType } = require("../../dist/src"); // require("@klaytn/ethers-ext");
+const { Wallet, TxType, parseKlay } = require("@klaytn/ethers-ext");
 
 //
 // TxTypeValueTransfer
@@ -16,7 +16,7 @@ async function main() {
   let tx = {
       type: TxType.ValueTransfer,
       to: recieverAddr,
-      value: 100000000000,
+      value: parseKlay("1"),
       from: senderAddr,
     }; 
   

--- a/ethers-ext/example/transactions/Basic_08_TxTypeValueTransfer.js
+++ b/ethers-ext/example/transactions/Basic_08_TxTypeValueTransfer.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
+const { Wallet, TxType } = require("../../dist/src"); // require("@klaytn/ethers-ext");
 
 //
 // TxTypeValueTransfer
@@ -14,7 +14,7 @@ async function main() {
   const wallet = new Wallet(senderPriv, provider);
 
   let tx = {
-      type: Klaytn.TxTypeValueTransfer,
+      type: TxType.ValueTransfer,
       to: recieverAddr,
       value: 100000000000,
       from: senderAddr,

--- a/ethers-ext/example/transactions/Basic_10_TxTypeValueTransferMemo.js
+++ b/ethers-ext/example/transactions/Basic_10_TxTypeValueTransferMemo.js
@@ -1,11 +1,9 @@
 const ethers = require("ethers");
-const { Wallet } = require("@klaytn/ethers-ext");
+const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
 
 //
 // TxTypeValueTransferMemo
 // https://docs.klaytn.foundation/content/klaytn/design/transactions/basic#txtypevaluetransfermemo
-// 
-//   type: Must be 0x10,
 // 
 
 const recieverAddr = '0xc40b6909eb7085590e1c26cb3becc25368e249e9' 
@@ -17,7 +15,7 @@ async function main() {
   const wallet = new Wallet(senderPriv, provider);
 
   tx = {
-      type: 0x10,         
+      type: Klaytn.TxTypeValueTransferMemo,         
       to: recieverAddr,
       value: 1e12,
       from: senderAddr,

--- a/ethers-ext/example/transactions/Basic_10_TxTypeValueTransferMemo.js
+++ b/ethers-ext/example/transactions/Basic_10_TxTypeValueTransferMemo.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
+const { Wallet, TxType, parseKlay } = require("@klaytn/ethers-ext");
 
 //
 // TxTypeValueTransferMemo
@@ -15,9 +15,9 @@ async function main() {
   const wallet = new Wallet(senderPriv, provider);
 
   tx = {
-      type: Klaytn.TxTypeValueTransferMemo,         
+      type: TxType.ValueTransferMemo,         
       to: recieverAddr,
-      value: 1e12,
+      value: parseKlay("1"),
       from: senderAddr,
       input: "0x1234567890",
     }; 

--- a/ethers-ext/example/transactions/Basic_20_TxTypeAccountUpdate.js
+++ b/ethers-ext/example/transactions/Basic_20_TxTypeAccountUpdate.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
+const { Wallet, TxType } = require("@klaytn/ethers-ext");
 
 //
 // TxTypeAccountUpdate
@@ -21,7 +21,7 @@ async function main() {
   const wallet = new Wallet(senderPriv, provider);
 
   let tx = {
-        type: Klaytn.TxTypeAccountUpdate,
+        type: TxType.AccountUpdate,
         from: senderAddr,
         key: {
             type: 0x02, 

--- a/ethers-ext/example/transactions/Basic_20_TxTypeAccountUpdate.js
+++ b/ethers-ext/example/transactions/Basic_20_TxTypeAccountUpdate.js
@@ -1,11 +1,10 @@
 const ethers = require("ethers");
-const { Wallet } = require("@klaytn/ethers-ext");
+const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
 
 //
 // TxTypeAccountUpdate
 // https://docs.klaytn.foundation/content/klaytn/design/transactions/basic#txtypeaccountupdate
 // 
-//   type: Must be 0x20,
 //   from: address of sender to be updated
 //   key: Refer Klaytn account key
 //        https://docs.klaytn.foundation/content/klaytn/design/accounts#account-key 
@@ -22,7 +21,7 @@ async function main() {
   const wallet = new Wallet(senderPriv, provider);
 
   let tx = {
-        type: 0x20,
+        type: Klaytn.TxTypeAccountUpdate,
         from: senderAddr,
         key: {
             type: 0x02, 

--- a/ethers-ext/example/transactions/Basic_28_TxTypeSmartContractDeploy.js
+++ b/ethers-ext/example/transactions/Basic_28_TxTypeSmartContractDeploy.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
+const { Wallet, TxType } = require("@klaytn/ethers-ext");
 
 //
 // TxTypeSmartContractDeploy
@@ -20,7 +20,7 @@ async function main() {
   const wallet = new Wallet(senderPriv, provider);
 
   tx = {
-      type: Klaytn.TxTypeSmartContractDeploy,
+      type: TxType.SmartContractDeploy,
       to:    "0x0000000000000000000000000000000000000000",
       value: 0,  
       from: senderAddr,

--- a/ethers-ext/example/transactions/Basic_28_TxTypeSmartContractDeploy.js
+++ b/ethers-ext/example/transactions/Basic_28_TxTypeSmartContractDeploy.js
@@ -1,11 +1,10 @@
 const ethers = require("ethers");
-const { Wallet } = require("@klaytn/ethers-ext");
+const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
 
 //
 // TxTypeSmartContractDeploy
 // https://docs.klaytn.foundation/content/klaytn/design/transactions/basic#txtypesmartcontractdeploy
 // 
-//   type: Must be 0x28,
 //   to:    Must be "0x0000000000000000000000000000000000000000",
 //   value: Must be 0, if not payable
 //   input: SmartContract binary, 
@@ -21,7 +20,7 @@ async function main() {
   const wallet = new Wallet(senderPriv, provider);
 
   tx = {
-      type: 0x28,
+      type: Klaytn.TxTypeSmartContractDeploy,
       to:    "0x0000000000000000000000000000000000000000",
       value: 0,  
       from: senderAddr,

--- a/ethers-ext/example/transactions/Basic_30_TxTypeSmartContractExecution.js
+++ b/ethers-ext/example/transactions/Basic_30_TxTypeSmartContractExecution.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet } = require("@klaytn/ethers-ext");
+const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
 
 const senderAddr = '0xa2a8854b1802d8cd5de631e690817c253d6a9153'  
 const senderPriv = '0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8'
@@ -9,7 +9,6 @@ const contractAddr = '0xD7fA6634bDDe0B2A9d491388e2fdeD0fa25D2067'
 // TxTypeSmartContractExecution
 // https://docs.klaytn.foundation/content/klaytn/design/transactions/basic#txtypesmartcontractexecution
 // 
-//   type: Must be 0x30,
 //   to : deployed contract address 
 //   value: Must be 0, if not payable
 //   input: Refer ethers.utils.interface.encodeFunctionData
@@ -36,7 +35,7 @@ async function main() {
   const param = contract.interface.encodeFunctionData("setNumber", ["0x123"]); 
 
   tx = {
-      type: 0x30,
+      type: Klaytn.TxTypeSmartContractExecution,
       to: contractAddr,
       value: 0,  
       from: senderAddr,

--- a/ethers-ext/example/transactions/Basic_30_TxTypeSmartContractExecution.js
+++ b/ethers-ext/example/transactions/Basic_30_TxTypeSmartContractExecution.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
+const { Wallet, TxType } = require("@klaytn/ethers-ext");
 
 const senderAddr = '0xa2a8854b1802d8cd5de631e690817c253d6a9153'  
 const senderPriv = '0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8'
@@ -35,7 +35,7 @@ async function main() {
   const param = contract.interface.encodeFunctionData("setNumber", ["0x123"]); 
 
   tx = {
-      type: Klaytn.TxTypeSmartContractExecution,
+      type: TxType.SmartContractExecution,
       to: contractAddr,
       value: 0,  
       from: senderAddr,

--- a/ethers-ext/example/transactions/Basic_38_TxTypeCancel.js
+++ b/ethers-ext/example/transactions/Basic_38_TxTypeCancel.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
+const { Wallet, TxType } = require("@klaytn/ethers-ext");
 
 const senderAddr = '0xa2a8854b1802d8cd5de631e690817c253d6a9153'  
 const senderPriv = '0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8'
@@ -21,7 +21,7 @@ async function main() {
   // 1) send ValueTransfer tx with the next nonce+1
   let nextNonce = await wallet.getTransactionCount();
   let tx = {
-      type: Klaytn.TxTypeValueTransfer,    
+      type: TxType.ValueTransfer,    
       nonce: nextNonce + 1,     
       to: recieverAddr,
       value: 1e12,
@@ -33,7 +33,7 @@ async function main() {
 
   // 2) send Cancel tx with the next nonce+1 
   let txCancel = {
-    type: Klaytn.TxTypeCancel,
+    type: TxType.Cancel,
     nonce: nextNonce + 1, 
     from: senderAddr, 
   };

--- a/ethers-ext/example/transactions/Basic_38_TxTypeCancel.js
+++ b/ethers-ext/example/transactions/Basic_38_TxTypeCancel.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet } = require("@klaytn/ethers-ext");
+const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
 
 const senderAddr = '0xa2a8854b1802d8cd5de631e690817c253d6a9153'  
 const senderPriv = '0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8'
@@ -8,8 +8,6 @@ const recieverAddr = '0xc40b6909eb7085590e1c26cb3becc25368e249e9'
 //
 // TxTypeCancel
 // https://docs.klaytn.foundation/content/klaytn/design/transactions/basic#txtypecancel
-// 
-//   type: Must be 0x38,
 //
 // 1) send ValueTransfer tx with the next nonce + 1  
 // 2) send Cancel tx with the next nonce + 1 
@@ -23,7 +21,7 @@ async function main() {
   // 1) send ValueTransfer tx with the next nonce+1
   let nextNonce = await wallet.getTransactionCount();
   let tx = {
-      type: 8,    
+      type: Klaytn.TxTypeValueTransfer,    
       nonce: nextNonce + 1,     
       to: recieverAddr,
       value: 1e12,
@@ -35,7 +33,7 @@ async function main() {
 
   // 2) send Cancel tx with the next nonce+1 
   let txCancel = {
-    type: 0x38,
+    type: Klaytn.TxTypeCancel,
     nonce: nextNonce + 1, 
     from: senderAddr, 
   };

--- a/ethers-ext/example/transactions/FeeDel_09_TxTypeFeeDelegatedValueTransfer.js
+++ b/ethers-ext/example/transactions/FeeDel_09_TxTypeFeeDelegatedValueTransfer.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
+const { Wallet, TxType } = require("@klaytn/ethers-ext");
  
 //
 // TxTypeFeeDelegatedValueTransfer
@@ -20,7 +20,7 @@ async function main() {
   const senderWallet = new Wallet(senderPriv, provider);
   
   let tx = {
-    type: Klaytn.TxTypeFeeDelegatedValueTransfer,    
+    type: TxType.FeeDelegatedValueTransfer,    
     to: recieverAddr,
     value: 1e12,
     from: senderAddr,

--- a/ethers-ext/example/transactions/FeeDel_09_TxTypeFeeDelegatedValueTransfer.js
+++ b/ethers-ext/example/transactions/FeeDel_09_TxTypeFeeDelegatedValueTransfer.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, TxType } = require("@klaytn/ethers-ext");
+const { Wallet, TxType, parseKlay } = require("@klaytn/ethers-ext");
  
 //
 // TxTypeFeeDelegatedValueTransfer
@@ -22,7 +22,7 @@ async function main() {
   let tx = {
     type: TxType.FeeDelegatedValueTransfer,    
     to: recieverAddr,
-    value: 1e12,
+    value: parseKlay("1"),
     from: senderAddr,
   }; 
 

--- a/ethers-ext/example/transactions/FeeDel_09_TxTypeFeeDelegatedValueTransfer.js
+++ b/ethers-ext/example/transactions/FeeDel_09_TxTypeFeeDelegatedValueTransfer.js
@@ -1,12 +1,9 @@
 const ethers = require("ethers");
-const { Wallet } = require("@klaytn/ethers-ext");
+const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
  
 //
 // TxTypeFeeDelegatedValueTransfer
 // https://docs.klaytn.foundation/content/klaytn/design/transactions/fee-delegation#txtypefeedelegatedvaluetransfer
-// 
-//   type: Must be 0x09,
-//   nonce: In signTransactionAsFeePayer, must not be omitted, because feePayer's nonce is filled when populating
 // 
 
 const senderAddr = '0xa2a8854b1802d8cd5de631e690817c253d6a9153' 
@@ -23,7 +20,7 @@ async function main() {
   const senderWallet = new Wallet(senderPriv, provider);
   
   let tx = {
-    type: 9,    
+    type: Klaytn.TxTypeFeeDelegatedValueTransfer,    
     to: recieverAddr,
     value: 1e12,
     from: senderAddr,

--- a/ethers-ext/example/transactions/FeeDel_11_TxTypeFeeDelegatedValueTransferMemo.js
+++ b/ethers-ext/example/transactions/FeeDel_11_TxTypeFeeDelegatedValueTransferMemo.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
+const { Wallet, TxType } = require("@klaytn/ethers-ext");
 
 //
 // TxTypeFeeDelegatedValueTransferMemo
@@ -20,7 +20,7 @@ async function main() {
   const senderWallet = new Wallet(senderPriv, provider);
   
   let tx = {
-      type: Klaytn.TxTypeFeeDelegatedValueTransferMemo,         
+      type: TxType.FeeDelegatedValueTransferMemo,         
       to: recieverAddr,
       value: 1e12,
       from: senderAddr,

--- a/ethers-ext/example/transactions/FeeDel_11_TxTypeFeeDelegatedValueTransferMemo.js
+++ b/ethers-ext/example/transactions/FeeDel_11_TxTypeFeeDelegatedValueTransferMemo.js
@@ -1,12 +1,9 @@
 const ethers = require("ethers");
-const { Wallet } = require("@klaytn/ethers-ext");
+const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
 
 //
 // TxTypeFeeDelegatedValueTransferMemo
 // https://docs.klaytn.foundation/content/klaytn/design/transactions/fee-delegation#txtypefeedelegatedvaluetransfermemo
-// 
-//   type: Must be 0x11,
-//   nonce: In signTransactionAsFeePayer, must not be omitted, because feePayer's nonce is filled when populating
 // 
 
 const senderAddr = '0xa2a8854b1802d8cd5de631e690817c253d6a9153' 
@@ -17,21 +14,13 @@ const recieverAddr = '0xc40b6909eb7085590e1c26cb3becc25368e249e9'
 
 const provider = new ethers.providers.JsonRpcProvider('https://public-en-baobab.klaytn.net')
 
-async function doSender() {
-
-}
-
-async function doFeePayer( senderTxHashRLP ) {
-  
-}
-
 async function main() {
 
   // sender
   const senderWallet = new Wallet(senderPriv, provider);
   
   let tx = {
-      type: 0x11,         
+      type: Klaytn.TxTypeFeeDelegatedValueTransferMemo,         
       to: recieverAddr,
       value: 1e12,
       from: senderAddr,

--- a/ethers-ext/example/transactions/FeeDel_11_TxTypeFeeDelegatedValueTransferMemo.js
+++ b/ethers-ext/example/transactions/FeeDel_11_TxTypeFeeDelegatedValueTransferMemo.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, TxType } = require("@klaytn/ethers-ext");
+const { Wallet, TxType, parseKlay } = require("@klaytn/ethers-ext");
 
 //
 // TxTypeFeeDelegatedValueTransferMemo
@@ -22,7 +22,7 @@ async function main() {
   let tx = {
       type: TxType.FeeDelegatedValueTransferMemo,         
       to: recieverAddr,
-      value: 1e12,
+      value: parseKlay("1"),
       from: senderAddr,
       input: "0x1234567890",
     }; 

--- a/ethers-ext/example/transactions/FeeDel_21_TxTypeFeeDelegatedAccountUpdate.js
+++ b/ethers-ext/example/transactions/FeeDel_21_TxTypeFeeDelegatedAccountUpdate.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
+const { Wallet, TxType, AccountKeyType } = require("@klaytn/ethers-ext");
 
 //
 // TxTypeFeeDelegatedAccountUpdate
@@ -22,14 +22,15 @@ async function main() {
   const senderWallet = new Wallet(senderPriv, provider);
   
   let tx = {
-      type: Klaytn.TxTypeFeeDelegatedAccountUpdate,
+      type: TxType.FeeDelegatedAccountUpdate,
       from: senderAddr,
       key: {
-          type: 0x02, 
+          type: AccountKeyType.Public, 
           // private key 0xf8cc7c3813ad23817466b1802ee805ee417001fcce9376ab8728c92dd8ea0a6b
           // pubkeyX 0xdbac81e8486d68eac4e6ef9db617f7fbd79a04a3b323c982a09cdfc61f0ae0e8
           // pubkeyY 0x906d7170ba349c86879fb8006134cbf57bda9db9214a90b607b6b4ab57fc026e
-          key: "0x02dbac81e8486d68eac4e6ef9db617f7fbd79a04a3b323c982a09cdfc61f0ae0e8",
+          // Compressed PublicKey "0x02dbac81e8486d68eac4e6ef9db617f7fbd79a04a3b323c982a09cdfc61f0ae0e8",
+          key: ethers.utils.computePublicKey('0xf8cc7c3813ad23817466b1802ee805ee417001fcce9376ab8728c92dd8ea0a6b', true)
       }
   };
 

--- a/ethers-ext/example/transactions/FeeDel_21_TxTypeFeeDelegatedAccountUpdate.js
+++ b/ethers-ext/example/transactions/FeeDel_21_TxTypeFeeDelegatedAccountUpdate.js
@@ -1,13 +1,10 @@
 const ethers = require("ethers");
-const { Wallet } = require("@klaytn/ethers-ext");
+const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
 
 //
 // TxTypeFeeDelegatedAccountUpdate
 // https://docs.klaytn.foundation/content/klaytn/design/transactions/fee-delegation#txtypefeedelegatedaccountupdate
-// 
-//   type: Must be 0x21,
-//   nonce: In signTransactionAsFeePayer, must not be omitted, because feePayer's nonce is filled when populating
-// 
+//  
 
 // create new account for testing 
 // https://baobab.wallet.klaytn.foundation/ 
@@ -25,7 +22,7 @@ async function main() {
   const senderWallet = new Wallet(senderPriv, provider);
   
   let tx = {
-      type: 0x21,
+      type: Klaytn.TxTypeFeeDelegatedAccountUpdate,
       from: senderAddr,
       key: {
           type: 0x02, 

--- a/ethers-ext/example/transactions/FeeDel_29_TxTypeFeeDelegatedSmartContractDeploy.js
+++ b/ethers-ext/example/transactions/FeeDel_29_TxTypeFeeDelegatedSmartContractDeploy.js
@@ -1,10 +1,9 @@
 const ethers = require("ethers");
-const { Wallet } = require("@klaytn/ethers-ext");
+const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
 
 // TxTypeFeeDelegatedSmartContractDeploy
 // https://docs.klaytn.foundation/content/klaytn/design/transactions/fee-delegation#txtypefeedelegatedsmartcontractdeploy
 // 
-//   type: Must be 0x29,
 //   to:    Must be "0x0000000000000000000000000000000000000000",
 //   value: Must be 0, if not payable
 //   input: SmartContract binary, 
@@ -25,7 +24,7 @@ async function main() {
   const senderWallet = new Wallet(senderPriv, provider);
   
   let tx = {
-    type: 0x29,
+    type: Klaytn.TxTypeFeeDelegatedSmartContractDeploy,
     to:    "0x0000000000000000000000000000000000000000",
     value: 0,  
     from: senderAddr,

--- a/ethers-ext/example/transactions/FeeDel_29_TxTypeFeeDelegatedSmartContractDeploy.js
+++ b/ethers-ext/example/transactions/FeeDel_29_TxTypeFeeDelegatedSmartContractDeploy.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
+const { Wallet, TxType } = require("@klaytn/ethers-ext");
 
 // TxTypeFeeDelegatedSmartContractDeploy
 // https://docs.klaytn.foundation/content/klaytn/design/transactions/fee-delegation#txtypefeedelegatedsmartcontractdeploy
@@ -24,7 +24,7 @@ async function main() {
   const senderWallet = new Wallet(senderPriv, provider);
   
   let tx = {
-    type: Klaytn.TxTypeFeeDelegatedSmartContractDeploy,
+    type: TxType.FeeDelegatedSmartContractDeploy,
     to:    "0x0000000000000000000000000000000000000000",
     value: 0,  
     from: senderAddr,

--- a/ethers-ext/example/transactions/FeeDel_31_TxTypeFeeDelegatedSmartContractExecution.js
+++ b/ethers-ext/example/transactions/FeeDel_31_TxTypeFeeDelegatedSmartContractExecution.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
+const { Wallet, TxType } = require("@klaytn/ethers-ext");
 
 // TxTypeFeeDelegatedSmartContractExecution
 // https://docs.klaytn.foundation/content/klaytn/design/transactions/fee-delegation#txtypefeedelegatedsmartcontractexecution
@@ -38,7 +38,7 @@ async function main() {
   const param = contract.interface.encodeFunctionData("setNumber", ["0x123"]); 
 
   let tx = {
-      type: Klaytn.TxTypeFeeDelegatedSmartContractExecution,
+      type: TxType.FeeDelegatedSmartContractExecution,
       to: CONTRACT_ADDRESS,
       value: 0,  
       from: senderAddr,

--- a/ethers-ext/example/transactions/FeeDel_31_TxTypeFeeDelegatedSmartContractExecution.js
+++ b/ethers-ext/example/transactions/FeeDel_31_TxTypeFeeDelegatedSmartContractExecution.js
@@ -1,10 +1,9 @@
 const ethers = require("ethers");
-const { Wallet } = require("@klaytn/ethers-ext");
+const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
 
 // TxTypeFeeDelegatedSmartContractExecution
 // https://docs.klaytn.foundation/content/klaytn/design/transactions/fee-delegation#txtypefeedelegatedsmartcontractexecution
 // 
-//   type: Must be 0x31,
 //   to : deployed contract address 
 //   value: Must be 0, if not payable
 //   input: Refer ethers.utils.interface.encodeFunctionData
@@ -39,7 +38,7 @@ async function main() {
   const param = contract.interface.encodeFunctionData("setNumber", ["0x123"]); 
 
   let tx = {
-      type: 0x31,
+      type: Klaytn.TxTypeFeeDelegatedSmartContractExecution,
       to: CONTRACT_ADDRESS,
       value: 0,  
       from: senderAddr,

--- a/ethers-ext/example/transactions/FeeDel_39_TxTypeFeeDelegatedCancel.js
+++ b/ethers-ext/example/transactions/FeeDel_39_TxTypeFeeDelegatedCancel.js
@@ -43,7 +43,7 @@ async function senderSign( nextNonce ) {
 async function feePayerSign( senderTxHashRLP ) {
   const feePayerWallet = new Wallet(feePayerPriv, provider);
 
-  const txCancel = objectFromRLP( senderTxHashRLP );
+  const txCancel = feePayerWallet.decodeTxFromRLP( senderTxHashRLP );
   txCancel.feePayer = feePayerAddr;
   console.log(txCancel);
 

--- a/ethers-ext/example/transactions/FeeDel_39_TxTypeFeeDelegatedCancel.js
+++ b/ethers-ext/example/transactions/FeeDel_39_TxTypeFeeDelegatedCancel.js
@@ -1,11 +1,9 @@
 const ethers = require("ethers");
-const { Wallet } = require("@klaytn/ethers-ext");
+const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
 
 //
 // TxTypeFeeDelegatedCancel
 // https://docs.klaytn.foundation/content/klaytn/design/transactions/fee-delegation#txtypefeedelegatedcancel
-// 
-//   type: Must be 0x39,
 //
 // 1) send ValueTransfer tx with the next nonce + 1  
 // 2) send Cancel tx with the next nonce + 1 
@@ -26,7 +24,7 @@ async function senderSign( nextNonce ) {
   const senderWallet = new Wallet(senderPriv, provider);
   
   let txCancel = {
-    type: 0x39,
+    type: Klaytn.TxTypeFeeDelegatedCancel,
     nonce: nextNonce + 1,
     from: senderAddr, 
   };
@@ -57,7 +55,7 @@ async function main() {
   // 1) send ValueTransfer tx with the next nonce + 1
   let nextNonce = await wallet.getTransactionCount();
   let tx = {
-      type: 8,      
+      type: Klaytn.TxTypeValueTransfer,      
       nonce: nextNonce + 1,        
       to: recieverAddr,
       value: 1e12,

--- a/ethers-ext/example/transactions/FeeDel_39_TxTypeFeeDelegatedCancel.js
+++ b/ethers-ext/example/transactions/FeeDel_39_TxTypeFeeDelegatedCancel.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
+const { Wallet, TxType } = require("@klaytn/ethers-ext");
 
 //
 // TxTypeFeeDelegatedCancel
@@ -24,7 +24,7 @@ async function senderSign( nextNonce ) {
   const senderWallet = new Wallet(senderPriv, provider);
   
   let txCancel = {
-    type: Klaytn.TxTypeFeeDelegatedCancel,
+    type: TxType.FeeDelegatedCancel,
     nonce: nextNonce + 1,
     from: senderAddr, 
   };
@@ -55,7 +55,7 @@ async function main() {
   // 1) send ValueTransfer tx with the next nonce + 1
   let nextNonce = await wallet.getTransactionCount();
   let tx = {
-      type: Klaytn.TxTypeValueTransfer,      
+      type: TxType.ValueTransfer,      
       nonce: nextNonce + 1,        
       to: recieverAddr,
       value: 1e12,

--- a/ethers-ext/example/transactions/PartialFeeDel_0a_TxTypeFeeDelegatedValueTransferWithRatio.js
+++ b/ethers-ext/example/transactions/PartialFeeDel_0a_TxTypeFeeDelegatedValueTransferWithRatio.js
@@ -1,12 +1,9 @@
 const ethers = require("ethers");
-const { Wallet } = require("@klaytn/ethers-ext");
+const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
 
 //
 // TxTypeFeeDelegatedValueTransferWithRatio
 // https://docs.klaytn.foundation/content/klaytn/design/transactions/partial-fee-delegation#txtypefeedelegatedvaluetransferwithratio
-// 
-//   type: Must be 0x0a,
-//   nonce: In signTransactionAsFeePayer, must not be omitted, because feePayer's nonce is filled when populating
 // 
 
 const senderAddr = '0xa2a8854b1802d8cd5de631e690817c253d6a9153' 
@@ -22,7 +19,7 @@ async function main() {
   const senderWallet = new Wallet(senderPriv, provider);
   
   let tx = {
-    type: 0x0a,    
+    type: Klaytn.TxTypeFeeDelegatedValueTransferWithRatio,    
     to: recieverAddr,
     value: 1e12,
     from: senderAddr,

--- a/ethers-ext/example/transactions/PartialFeeDel_0a_TxTypeFeeDelegatedValueTransferWithRatio.js
+++ b/ethers-ext/example/transactions/PartialFeeDel_0a_TxTypeFeeDelegatedValueTransferWithRatio.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
+const { Wallet, TxType } = require("@klaytn/ethers-ext");
 
 //
 // TxTypeFeeDelegatedValueTransferWithRatio
@@ -19,7 +19,7 @@ async function main() {
   const senderWallet = new Wallet(senderPriv, provider);
   
   let tx = {
-    type: Klaytn.TxTypeFeeDelegatedValueTransferWithRatio,    
+    type: TxType.FeeDelegatedValueTransferWithRatio,    
     to: recieverAddr,
     value: 1e12,
     from: senderAddr,

--- a/ethers-ext/example/transactions/PartialFeeDel_0a_TxTypeFeeDelegatedValueTransferWithRatio.js
+++ b/ethers-ext/example/transactions/PartialFeeDel_0a_TxTypeFeeDelegatedValueTransferWithRatio.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, TxType } = require("@klaytn/ethers-ext");
+const { Wallet, TxType, parseKlay } = require("@klaytn/ethers-ext");
 
 //
 // TxTypeFeeDelegatedValueTransferWithRatio
@@ -21,7 +21,7 @@ async function main() {
   let tx = {
     type: TxType.FeeDelegatedValueTransferWithRatio,    
     to: recieverAddr,
-    value: 1e12,
+    value: parseKlay("1"),
     from: senderAddr,
     feeRatio: 40,
   }; 

--- a/ethers-ext/example/transactions/PartialFeeDel_12_TxTypeFeeDelegatedValueTransferMemoWithRatio.js
+++ b/ethers-ext/example/transactions/PartialFeeDel_12_TxTypeFeeDelegatedValueTransferMemoWithRatio.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, TxType } = require("@klaytn/ethers-ext");
+const { Wallet, TxType, parseKlay } = require("@klaytn/ethers-ext");
 
 //
 // TxTypeFeeDelegatedValueTransferMemoWithRatio
@@ -23,7 +23,7 @@ async function main() {
   let tx = {
     type: TxType.FeeDelegatedValueTransferMemoWithRatio,         
     to: recieverAddr,
-    value: 1e12,
+    value: parseKlay("1"),
     from: senderAddr,
     input: "0x1234567890",
     feeRatio: 30,

--- a/ethers-ext/example/transactions/PartialFeeDel_12_TxTypeFeeDelegatedValueTransferMemoWithRatio.js
+++ b/ethers-ext/example/transactions/PartialFeeDel_12_TxTypeFeeDelegatedValueTransferMemoWithRatio.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
+const { Wallet, TxType } = require("@klaytn/ethers-ext");
 
 //
 // TxTypeFeeDelegatedValueTransferMemoWithRatio
@@ -21,7 +21,7 @@ async function main() {
   const senderWallet = new Wallet(senderPriv, provider);
   
   let tx = {
-    type: Klaytn.TxTypeFeeDelegatedValueTransferMemoWithRatio,         
+    type: TxType.FeeDelegatedValueTransferMemoWithRatio,         
     to: recieverAddr,
     value: 1e12,
     from: senderAddr,

--- a/ethers-ext/example/transactions/PartialFeeDel_12_TxTypeFeeDelegatedValueTransferMemoWithRatio.js
+++ b/ethers-ext/example/transactions/PartialFeeDel_12_TxTypeFeeDelegatedValueTransferMemoWithRatio.js
@@ -1,11 +1,10 @@
 const ethers = require("ethers");
-const { Wallet } = require("@klaytn/ethers-ext");
+const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
 
 //
 // TxTypeFeeDelegatedValueTransferMemoWithRatio
 // https://docs.klaytn.foundation/content/klaytn/design/transactions/partial-fee-delegation#txtypefeedelegatedvaluetransfermemowithratio
 // 
-//   type: Must be 0x12,
 //   nonce: In signTransactionAsFeePayer, must not be omitted, because feePayer's nonce is filled when populating
 // 
 
@@ -22,7 +21,7 @@ async function main() {
   const senderWallet = new Wallet(senderPriv, provider);
   
   let tx = {
-    type: 0x12,         
+    type: Klaytn.TxTypeFeeDelegatedValueTransferMemoWithRatio,         
     to: recieverAddr,
     value: 1e12,
     from: senderAddr,

--- a/ethers-ext/example/transactions/PartialFeeDel_22_TxTypeFeeDelegatedAccountUpdateWithRatio.js
+++ b/ethers-ext/example/transactions/PartialFeeDel_22_TxTypeFeeDelegatedAccountUpdateWithRatio.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
+const { Wallet, TxType, AccountKeyType } = require("@klaytn/ethers-ext");
 
 //
 // TxTypeFeeDelegatedAccountUpdateWithRatio
@@ -32,17 +32,18 @@ async function main() {
   const senderWallet = new Wallet(senderPriv, provider);
   
   let tx = {
-      type: Klaytn.TxTypeFeeDelegatedAccountUpdateWithRatio,
+      type: TxType.FeeDelegatedAccountUpdateWithRatio,
       // gasLimit was 56000
       // https://baobab.scope.klaytn.com/tx/0x2a9fc23547e58f67d83263e509e0dc987ada346521a95d8f48de4e023796dede?tabId=accountKeyInfo
       gasLimit: 60000,  
       from: senderAddr,
       key: {
-          type: 0x02, 
+          type: AccountKeyType.Public, 
           // private key 0xf8cc7c3813ad23817466b1802ee805ee417001fcce9376ab8728c92dd8ea0a6b
           // pubkeyX 0xdbac81e8486d68eac4e6ef9db617f7fbd79a04a3b323c982a09cdfc61f0ae0e8
           // pubkeyY 0x906d7170ba349c86879fb8006134cbf57bda9db9214a90b607b6b4ab57fc026e
-          key: "0x02dbac81e8486d68eac4e6ef9db617f7fbd79a04a3b323c982a09cdfc61f0ae0e8",
+          // Compressed PublicKey "0x02dbac81e8486d68eac4e6ef9db617f7fbd79a04a3b323c982a09cdfc61f0ae0e8",
+          key: ethers.utils.computePublicKey('0xf8cc7c3813ad23817466b1802ee805ee417001fcce9376ab8728c92dd8ea0a6b', true)
       },
       feeRatio: 40, 
   };

--- a/ethers-ext/example/transactions/PartialFeeDel_22_TxTypeFeeDelegatedAccountUpdateWithRatio.js
+++ b/ethers-ext/example/transactions/PartialFeeDel_22_TxTypeFeeDelegatedAccountUpdateWithRatio.js
@@ -1,11 +1,10 @@
 const ethers = require("ethers");
-const { Wallet } = require("@klaytn/ethers-ext");
+const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
 
 //
 // TxTypeFeeDelegatedAccountUpdateWithRatio
 // https://docs.klaytn.foundation/content/klaytn/design/transactions/partial-fee-delegation#txtypefeedelegatedaccountupdatewithratio
 // 
-//   type: Must be 0x22,
 //   nonce: In signTransactionAsFeePayer, must not be omitted, because feePayer's nonce is filled when populating
 //   gasLimit: Must be large enough 
 //             If SDK users (wallet or dapp devs) want to add some margin, they can always
@@ -33,7 +32,7 @@ async function main() {
   const senderWallet = new Wallet(senderPriv, provider);
   
   let tx = {
-      type: 0x22,
+      type: Klaytn.TxTypeFeeDelegatedAccountUpdateWithRatio,
       // gasLimit was 56000
       // https://baobab.scope.klaytn.com/tx/0x2a9fc23547e58f67d83263e509e0dc987ada346521a95d8f48de4e023796dede?tabId=accountKeyInfo
       gasLimit: 60000,  

--- a/ethers-ext/example/transactions/PartialFeeDel_2a_TxTypeFeeDelegatedSmartContractDeployWithRatio.js
+++ b/ethers-ext/example/transactions/PartialFeeDel_2a_TxTypeFeeDelegatedSmartContractDeployWithRatio.js
@@ -1,10 +1,9 @@
 const ethers = require("ethers");
-const { Wallet } = require("@klaytn/ethers-ext");
+const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
 
-// TxTypeFeeDelegatedSmartContractExecutionWithRatio
+// TxTypeFeeDelegatedSmartContractDeployWithRatio
 // https://docs.klaytn.foundation/content/klaytn/design/transactions/partial-fee-delegation#txtypefeedelegatedsmartcontractdeploywithratio
 // 
-//   type: Must be 0x2a,
 //   to:    Must be "0x0000000000000000000000000000000000000000",
 //   value: Must be 0, if not payable
 //   input: SmartContract binary, 
@@ -24,7 +23,7 @@ async function main() {
   const senderWallet = new Wallet(senderPriv, provider);
   
   let tx = {
-    type: 0x2a,
+    type: Klaytn.TxTypeFeeDelegatedSmartContractDeployWithRatio,
     to:    "0x0000000000000000000000000000000000000000",
     value: 0,  
     from: senderAddr,

--- a/ethers-ext/example/transactions/PartialFeeDel_2a_TxTypeFeeDelegatedSmartContractDeployWithRatio.js
+++ b/ethers-ext/example/transactions/PartialFeeDel_2a_TxTypeFeeDelegatedSmartContractDeployWithRatio.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
+const { Wallet, TxType } = require("@klaytn/ethers-ext");
 
 // TxTypeFeeDelegatedSmartContractDeployWithRatio
 // https://docs.klaytn.foundation/content/klaytn/design/transactions/partial-fee-delegation#txtypefeedelegatedsmartcontractdeploywithratio
@@ -23,7 +23,7 @@ async function main() {
   const senderWallet = new Wallet(senderPriv, provider);
   
   let tx = {
-    type: Klaytn.TxTypeFeeDelegatedSmartContractDeployWithRatio,
+    type: TxType.FeeDelegatedSmartContractDeployWithRatio,
     to:    "0x0000000000000000000000000000000000000000",
     value: 0,  
     from: senderAddr,

--- a/ethers-ext/example/transactions/PartialFeeDel_32_TxTypeFeeDelegatedSmartContractExecutionWithRatio.js
+++ b/ethers-ext/example/transactions/PartialFeeDel_32_TxTypeFeeDelegatedSmartContractExecutionWithRatio.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
+const { Wallet, TxType } = require("@klaytn/ethers-ext");
 
 // TxTypeFeeDelegatedSmartContractExecutionWithRatio
 // https://docs.klaytn.foundation/content/klaytn/design/transactions/partial-fee-delegation#txtypefeedelegatedsmartcontractexecutionwithratio
@@ -38,7 +38,7 @@ async function main() {
   const param = contract.interface.encodeFunctionData("setNumber", ["0x123"]); 
 
   let tx = {
-      type: Klaytn.TxTypeFeeDelegatedSmartContractExecutionWithRatio, 
+      type: TxType.FeeDelegatedSmartContractExecutionWithRatio, 
       to: CONTRACT_ADDRESS,
       value: 0,  
       from: senderAddr,

--- a/ethers-ext/example/transactions/PartialFeeDel_32_TxTypeFeeDelegatedSmartContractExecutionWithRatio.js
+++ b/ethers-ext/example/transactions/PartialFeeDel_32_TxTypeFeeDelegatedSmartContractExecutionWithRatio.js
@@ -1,10 +1,9 @@
 const ethers = require("ethers");
-const { Wallet } = require("@klaytn/ethers-ext");
+const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
 
 // TxTypeFeeDelegatedSmartContractExecutionWithRatio
 // https://docs.klaytn.foundation/content/klaytn/design/transactions/partial-fee-delegation#txtypefeedelegatedsmartcontractexecutionwithratio
 // 
-//   type: Must be 0x32,
 //   to : deployed contract address 
 //   value: Must be 0, if not payable
 //   input: Refer ethers.utils.interface.encodeFunctionData
@@ -39,7 +38,7 @@ async function main() {
   const param = contract.interface.encodeFunctionData("setNumber", ["0x123"]); 
 
   let tx = {
-      type: 0x32, 
+      type: Klaytn.TxTypeFeeDelegatedSmartContractExecutionWithRatio, 
       to: CONTRACT_ADDRESS,
       value: 0,  
       from: senderAddr,

--- a/ethers-ext/example/transactions/PartialFeeDel_3a_TxTypeFeeDelegatedCancelWithRatio.js
+++ b/ethers-ext/example/transactions/PartialFeeDel_3a_TxTypeFeeDelegatedCancelWithRatio.js
@@ -1,5 +1,5 @@
 const ethers = require("ethers");
-const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
+const { Wallet, TxType } = require("@klaytn/ethers-ext");
 
 //
 // TxTypeFeeDelegatedCancelWithRatio
@@ -23,7 +23,7 @@ async function senderSign( nextNonce ) {
   const senderWallet = new Wallet(senderPriv, provider);
   
   let txCancel = {
-    type: Klaytn.TxTypeFeeDelegatedCancelWithRatio,
+    type: TxType.FeeDelegatedCancelWithRatio,
     nonce: nextNonce + 1, 
     from: senderAddr,
     feeRatio: 30, 
@@ -55,7 +55,7 @@ async function main() {
   // 1) send ValueTransfer tx with the next nonce + 1
   let nextNonce = await wallet.getTransactionCount();
   let tx = {
-      type: Klaytn.TxTypeValueTransfer,         
+      type: TxType.ValueTransfer,         
       nonce: nextNonce + 1,
       to: recieverAddr,
       value: 1e12,

--- a/ethers-ext/example/transactions/PartialFeeDel_3a_TxTypeFeeDelegatedCancelWithRatio.js
+++ b/ethers-ext/example/transactions/PartialFeeDel_3a_TxTypeFeeDelegatedCancelWithRatio.js
@@ -1,11 +1,9 @@
 const ethers = require("ethers");
-const { Wallet } = require("@klaytn/ethers-ext");
+const { Wallet, Klaytn } = require("@klaytn/ethers-ext");
 
 //
 // TxTypeFeeDelegatedCancelWithRatio
 // https://docs.klaytn.foundation/content/klaytn/design/transactions/partial-fee-delegation#txtypefeedelegatedcancelwithratio
-// 
-//   type: Must be 0x3a,
 //
 // 1) send ValueTransfer tx with the next nonce + 1  
 // 2) send Cancel tx with the next nonce + 1 
@@ -25,7 +23,7 @@ async function senderSign( nextNonce ) {
   const senderWallet = new Wallet(senderPriv, provider);
   
   let txCancel = {
-    type: 0x3a,
+    type: Klaytn.TxTypeFeeDelegatedCancelWithRatio,
     nonce: nextNonce + 1, 
     from: senderAddr,
     feeRatio: 30, 
@@ -57,7 +55,7 @@ async function main() {
   // 1) send ValueTransfer tx with the next nonce + 1
   let nextNonce = await wallet.getTransactionCount();
   let tx = {
-      type: 8,         
+      type: Klaytn.TxTypeValueTransfer,         
       nonce: nextNonce + 1,
       to: recieverAddr,
       value: 1e12,

--- a/ethers-ext/example/unit/formatKlaytnUnits.js
+++ b/ethers-ext/example/unit/formatKlaytnUnits.js
@@ -1,5 +1,5 @@
 const { BigNumber } = require("@ethersproject/bignumber");
-const { formatKlaytnUnits, formatKLAY } = require("@klaytn/ethers-ext");
+const { formatKlaytnUnits, formatKlay } = require("@klaytn/ethers-ext");
 
 // 
 // https://docs.klaytn.foundation/content/klaytn/design/klaytn-native-coin-klay
@@ -24,6 +24,9 @@ async function main() {
     console.log( formatKlaytnUnits(oneGpeb, "ston") );
     // '1.0'
 
+    console.log( formatKlaytnUnits(oneGpeb, "STON") );
+    // '1.0'
+
     console.log( formatKlaytnUnits(oneGpeb, 9) );
     // '1.0'
 
@@ -39,7 +42,7 @@ async function main() {
     console.log( formatKlaytnUnits(oneKLAY, 18) );
     // '1.0'
 
-    console.log( formatKLAY(oneKLAY) );
+    console.log( formatKlay(oneKLAY) );
     // '1.0'
 }
 

--- a/ethers-ext/example/unit/formatKlaytnUnits.js
+++ b/ethers-ext/example/unit/formatKlaytnUnits.js
@@ -1,0 +1,46 @@
+const { BigNumber } = require("@ethersproject/bignumber");
+const { formatKlaytnUnits, formatKLAY } = require("../../dist/src/core/util"); // require("@klaytn/sdk-ethers");
+
+// 
+// https://docs.klaytn.foundation/content/klaytn/design/klaytn-native-coin-klay
+// https://docs.ethers.org/v5/api/utils/display-logic/#display-logic--units
+//
+async function main() {
+    const oneGpeb = BigNumber.from("1000000000");
+    const oneKLAY = BigNumber.from("1000000000000000000");
+
+    console.log( formatKlaytnUnits(oneGpeb, 0) );
+    // '1000000000'
+
+    console.log( formatKlaytnUnits(oneGpeb, "kpeb") );
+    // '1000000.0'
+
+    console.log( formatKlaytnUnits(oneGpeb, "Mpeb") );
+    // '1000.0'
+
+    console.log( formatKlaytnUnits(oneGpeb, "Gpeb") );
+    // '1.0'
+
+    console.log( formatKlaytnUnits(oneGpeb, "ston") );
+    // '1.0'
+
+    console.log( formatKlaytnUnits(oneGpeb, 9) );
+    // '1.0'
+
+    console.log( formatKlaytnUnits(oneGpeb, "KLAY") );
+    // '0.000000001'
+
+    console.log( formatKlaytnUnits(oneKLAY, "KLAY") );
+    // '1.0'
+
+    console.log( formatKlaytnUnits(oneKLAY) );
+    // '1.0'
+
+    console.log( formatKlaytnUnits(oneKLAY, 18) );
+    // '1.0'
+
+    console.log( formatKLAY(oneKLAY) );
+    // '1.0'
+}
+
+main();

--- a/ethers-ext/example/unit/formatKlaytnUnits.js
+++ b/ethers-ext/example/unit/formatKlaytnUnits.js
@@ -1,5 +1,5 @@
 const { BigNumber } = require("@ethersproject/bignumber");
-const { formatKlaytnUnits, formatKLAY } = require("../../dist/src/core/util"); // require("@klaytn/sdk-ethers");
+const { formatKlaytnUnits, formatKLAY } = require("@klaytn/ethers-ext");
 
 // 
 // https://docs.klaytn.foundation/content/klaytn/design/klaytn-native-coin-klay

--- a/ethers-ext/example/unit/parseKlaytnUnits.js
+++ b/ethers-ext/example/unit/parseKlaytnUnits.js
@@ -1,5 +1,5 @@
 const { BigNumber } = require("@ethersproject/bignumber");
-const { parseKlaytnUnits, parseKLAY } = require("@klaytn/ethers-ext");
+const { parseKlaytnUnits, parseKlay } = require("@klaytn/ethers-ext");
 
 // 
 // https://docs.klaytn.foundation/content/klaytn/design/klaytn-native-coin-klay
@@ -20,6 +20,10 @@ async function main() {
     console.log( n.toString() );
     // "1000000000000000000"
     
+    n = BigNumber.from( parseKlaytnUnits("121.0", "StoN") );
+    console.log( n.toString() );
+    // "121000000000"
+
     n = BigNumber.from( parseKlaytnUnits("121.0", "Gpeb") );
     console.log( n.toString() );
     // "121000000000"
@@ -28,11 +32,11 @@ async function main() {
     console.log( n.toString() );
     // "121000000000"
     
-    n = BigNumber.from( parseKLAY("3.0") );
+    n = BigNumber.from( parseKlay("3.0") );
     console.log( n.toString() );
     // "3000000000000000000"
 
-    n = BigNumber.from( parseKLAY("0.5") );
+    n = BigNumber.from( parseKlay("0.5") );
     console.log( n.toString() );
     // "500000000000000000"
 }

--- a/ethers-ext/example/unit/parseKlaytnUnits.js
+++ b/ethers-ext/example/unit/parseKlaytnUnits.js
@@ -1,0 +1,40 @@
+const { BigNumber } = require("@ethersproject/bignumber");
+const { parseKlaytnUnits, parseKLAY } = require("@klaytn/ethers-ext");
+
+// 
+// https://docs.klaytn.foundation/content/klaytn/design/klaytn-native-coin-klay
+// https://docs.ethers.org/v5/api/utils/display-logic/#display-logic--units
+//
+async function main() {
+    let n = BigNumber.from( parseKlaytnUnits("1.0") );
+    console.log( n );
+    // { BigNumber: "1000000000000000000" }
+    console.log( n.toString() );
+    // "1000000000000000000"
+    
+    n = BigNumber.from( parseKlaytnUnits("1.0", "KLAY") );
+    console.log( n.toString() );
+    // "1000000000000000000"
+    
+    n = BigNumber.from( parseKlaytnUnits("1.0", 18) );
+    console.log( n.toString() );
+    // "1000000000000000000"
+    
+    n = BigNumber.from( parseKlaytnUnits("121.0", "Gpeb") );
+    console.log( n.toString() );
+    // "121000000000"
+    
+    n = BigNumber.from( parseKlaytnUnits("121.0", 9) );
+    console.log( n.toString() );
+    // "121000000000"
+    
+    n = BigNumber.from( parseKLAY("3.0") );
+    console.log( n.toString() );
+    // "3000000000000000000"
+
+    n = BigNumber.from( parseKLAY("0.5") );
+    console.log( n.toString() );
+    // "500000000000000000"
+}
+
+main();

--- a/ethers-ext/src/core/klaytn_tx.ts
+++ b/ethers-ext/src/core/klaytn_tx.ts
@@ -2,7 +2,8 @@ import _ from "lodash";
 import { FieldSet, FieldSetFactory } from "./field"
 import { SignatureLike, getSignatureTuple } from "./sig";
 import { HexStr } from "./util";
-import { parseTransaction } from "ethers/lib/utils";
+import { BigNumber, FixedNumber } from "ethers";
+import { hexValue, parseTransaction } from "ethers/lib/utils";
 import { TransactionRequest } from "@ethersproject/abstract-provider";
 
 export abstract class KlaytnTx extends FieldSet {
@@ -121,8 +122,9 @@ export function encodeTxForRPC( allowedKeys:string[], tx: TransactionRequest ): 
 
       if ( value == 0 || value === "0x0000000000000000000000000000000000000000") {
         value = "0x";
-      } else if ( typeof(value) == 'number' ) {
-        ttx[key] = HexStr.fromNumber(value);
+      } else if ( typeof(value) == 'number' || value instanceof BigNumber ) {
+        // https://github.com/ethers-io/ethers.js/blob/master/packages/providers/src.ts/json-rpc-provider.ts#L701
+        ttx[key] = hexValue( value );
       } else {
         ttx[key] = value;
       }

--- a/ethers-ext/src/core/util.ts
+++ b/ethers-ext/src/core/util.ts
@@ -82,20 +82,6 @@ export enum Klaytn {
 // https://docs.klaytn.foundation/content/klaytn/design/klaytn-native-coin-klay
 // https://docs.ethers.org/v5/api/utils/display-logic/#display-logic--units
 // https://github.com/ethers-io/ethers.js/blob/main/src.ts/utils/units.ts 
-const names = [
-  "peb",
-  "kpeb",
-  "Mpeb",
-  "Gpeb",
-  "ston",
-  "uKLAY",
-  "mKLAY",
-  "KLAY",
-  "kKLAY",
-  "MKLAY",
-  "GKLAY",
-  "TKLAY"
-];
 
 const KlayUnit = [
   { unit: 'peb', pebFactor: 0 },
@@ -112,10 +98,25 @@ const KlayUnit = [
   { unit: 'TKLAY', pebFactor: 30 },
 ];
 
+function isValidUnit(unit: string): boolean {
+  for ( let i=0; i < KlayUnit.length ; i++ ) {
+    if ( KlayUnit[i].unit.toLowerCase() === unit.toLowerCase() ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function getFactor(unit: string): number {
   for ( let i=0; i < KlayUnit.length ; i++ ) {
-    if ( KlayUnit[i].unit === unit) {
-      return KlayUnit[i].pebFactor;
+    if ( KlayUnit[i].unit.toLowerCase() === unit.toLowerCase() ) {
+      if (unit.toLowerCase() == 'mklay' && unit.charAt(0) == 'm') {
+        return 15;  // milli KLAY
+      } else if (unit.toLowerCase() == 'mklay' && unit.charAt(0) == 'M') {
+        return 24;  // Mega KLAY
+      } else {
+        return KlayUnit[i].pebFactor;
+      }
     }
   }
   assertArgument(false, "invalid unit", "unit", unit);
@@ -133,8 +134,7 @@ type Numeric = number | bigint;
 export function formatKlaytnUnits(value: BigNumberish, unit?: string | Numeric): string {
   let decimals = 18;
   if (typeof(unit) === "string") {
-      const index = names.indexOf(unit);
-      assertArgument(index >= 0, "invalid unit", "unit", unit);
+      assertArgument( isValidUnit(unit) == true, "invalid unit", "unit", unit);
       decimals = getFactor(unit);
   } else if (unit != null) {
       decimals = getNumber(unit, "unit");
@@ -154,8 +154,7 @@ export function parseKlaytnUnits(value: string, unit?: string | Numeric): bigint
 
   let decimals = 18;
   if (typeof(unit) === "string") {
-      const index = names.indexOf(unit);
-      assertArgument(index >= 0, "invalid unit", "unit", unit);
+      assertArgument( isValidUnit(unit) == true, "invalid unit", "unit", unit);
       decimals = getFactor( unit );
   } else if (unit != null) {
       decimals = getNumber(unit, "unit");
@@ -168,7 +167,7 @@ export function parseKlaytnUnits(value: string, unit?: string | Numeric): bigint
 /**
 *  Converts %%value%% into a //decimal string// using 18 decimal places.
 */
-export function formatKLAY(peb: BigNumberish): string {
+export function formatKlay(peb: BigNumberish): string {
   return formatKlaytnUnits(peb, 18);
 }
 
@@ -176,7 +175,7 @@ export function formatKLAY(peb: BigNumberish): string {
 *  Converts the //decimal string// %%ether%% to a BigInt, using 18
 *  decimal places.
 */
-export function parseKLAY(klay: string): bigint {
+export function parseKlay(klay: string): bigint {
   return parseKlaytnUnits(klay, 18);
 }
 

--- a/ethers-ext/src/core/util.ts
+++ b/ethers-ext/src/core/util.ts
@@ -45,37 +45,39 @@ export const HexStr = {
 };
 
 // Klaytn Type Enumeration
-export enum Klaytn {
+export enum TxType {
   // Basic
-  TxTypeValueTransfer = 0x08,
-  TxTypeValueTransferMemo = 0x10, 
-  TxTypeAccountUpdate = 0x20, 
-  TxTypeSmartContractDeploy = 0x28, 
-  TxTypeSmartContractExecution = 0x30, 
-  TxTypeCancel = 0x38, 
+  ValueTransfer = 0x08,
+  ValueTransferMemo = 0x10, 
+  AccountUpdate = 0x20, 
+  SmartContractDeploy = 0x28, 
+  SmartContractExecution = 0x30, 
+  Cancel = 0x38, 
 
   // Fee Delegation
-  TxTypeFeeDelegatedValueTransfer = 0x09,
-  TxTypeFeeDelegatedValueTransferMemo = 0x11, 
-  TxTypeFeeDelegatedAccountUpdate = 0x21, 
-  TxTypeFeeDelegatedSmartContractDeploy = 0x29, 
-  TxTypeFeeDelegatedSmartContractExecution = 0x31, 
-  TxTypeFeeDelegatedCancel = 0x39,
+  FeeDelegatedValueTransfer = 0x09,
+  FeeDelegatedValueTransferMemo = 0x11, 
+  FeeDelegatedAccountUpdate = 0x21, 
+  FeeDelegatedSmartContractDeploy = 0x29, 
+  FeeDelegatedSmartContractExecution = 0x31, 
+  FeeDelegatedCancel = 0x39,
 
   // Partial Fee Delegation 
-  TxTypeFeeDelegatedValueTransferWithRatio = 0x0a,
-  TxTypeFeeDelegatedValueTransferMemoWithRatio = 0x12,
-  TxTypeFeeDelegatedAccountUpdateWithRatio = 0x22, 
-  TxTypeFeeDelegatedSmartContractDeployWithRatio = 0x2a,
-  TxTypeFeeDelegatedSmartContractExecutionWithRatio = 0x32,
-  TxTypeFeeDelegatedCancelWithRatio = 0x3a,
+  FeeDelegatedValueTransferWithRatio = 0x0a,
+  FeeDelegatedValueTransferMemoWithRatio = 0x12,
+  FeeDelegatedAccountUpdateWithRatio = 0x22, 
+  FeeDelegatedSmartContractDeployWithRatio = 0x2a,
+  FeeDelegatedSmartContractExecutionWithRatio = 0x32,
+  FeeDelegatedCancelWithRatio = 0x3a,
+};
 
+export enum AccountKeyType {
   // Account Key Type
-  AccountKeyLegacy = 0x01,
-  AccountKeyPublic = 0x02,
-  AccountKeyFail = 0x03, 
-  AccountKeyWeightedMultiSig = 0x04, 
-  AccountKeyRoleBased = 0x05
+  Legacy = 0x01,
+  Public = 0x02,
+  Fail = 0x03, 
+  WeightedMultiSig = 0x04, 
+  RoleBased = 0x05
 };
 
 // For Klay unit
@@ -160,6 +162,8 @@ export function parseKlaytnUnits(value: string, unit?: string | Numeric): bigint
       decimals = getNumber(unit, "unit");
   }
 
+  // Original Ethers function returns FixedNumber.value, but we need to return BigNumber.
+  // https://github.com/ethers-io/ethers.js/blob/3c17cf56b5164236108269ac1e36d66e2843cd1e/src.ts/utils/units.ts#L75
   // @ts-ignore
   return FixedNumber.fromString(value, { decimals, width: 512 });
 }

--- a/ethers-ext/src/core/util.ts
+++ b/ethers-ext/src/core/util.ts
@@ -2,7 +2,7 @@ import _ from "lodash";
 import * as rlp from "@ethersproject/rlp";
 import * as bytes from "@ethersproject/bytes";
 import { BigNumber, BigNumberish } from "@ethersproject/bignumber";
-import { ethers } from "ethers";
+import { FixedNumber, ethers } from "ethers";
 import { computeAddress } from "ethers/lib/utils";
 
 export const RLP = {
@@ -43,3 +43,175 @@ export const HexStr = {
     return ethers.utils.hexZeroPad( value, length);
   }
 };
+
+// Klaytn Type Enumeration
+export enum Klaytn {
+  // Basic
+  TxTypeValueTransfer = 0x08,
+  TxTypeValueTransferMemo = 0x10, 
+  TxTypeAccountUpdate = 0x20, 
+  TxTypeSmartContractDeploy = 0x28, 
+  TxTypeSmartContractExecution = 0x30, 
+  TxTypeCancel = 0x38, 
+
+  // Fee Delegation
+  TxTypeFeeDelegatedValueTransfer = 0x09,
+  TxTypeFeeDelegatedValueTransferMemo = 0x11, 
+  TxTypeFeeDelegatedAccountUpdate = 0x21, 
+  TxTypeFeeDelegatedSmartContractDeploy = 0x29, 
+  TxTypeFeeDelegatedSmartContractExecution = 0x31, 
+  TxTypeFeeDelegatedCancel = 0x39,
+
+  // Partial Fee Delegation 
+  TxTypeFeeDelegatedValueTransferWithRatio = 0x0a,
+  TxTypeFeeDelegatedValueTransferMemoWithRatio = 0x12,
+  TxTypeFeeDelegatedAccountUpdateWithRatio = 0x22, 
+  TxTypeFeeDelegatedSmartContractDeployWithRatio = 0x2a,
+  TxTypeFeeDelegatedSmartContractExecutionWithRatio = 0x32,
+  TxTypeFeeDelegatedCancelWithRatio = 0x3a,
+
+  // Account Key Type
+  AccountKeyLegacy = 0x01,
+  AccountKeyPublic = 0x02,
+  AccountKeyFail = 0x03, 
+  AccountKeyWeightedMultiSig = 0x04, 
+  AccountKeyRoleBased = 0x05
+};
+
+
+// For Klay unit
+// https://github.com/ethers-io/ethers.js/blob/main/src.ts/utils/units.ts 
+// https://github.com/klaytn/caver-js/blob/82ba48c52bd3fc2738ccba40f67a4bd0f206822a/packages/caver-utils/src/index.js#L241C1-L420C2
+
+const names = [
+  "peb",
+  "kpeb",
+  "Mpeb",
+  "Gpeb",
+  "ston",
+  "Ston",
+  "uKLAY",
+  "mKLAY",
+  "KLAY",
+  "kKLAY",
+  "MKLAY",
+  "GKLAY",
+  "TKLAY"
+];
+
+const KlayUnit = [
+  { unit: 'peb', pebFactor: 0 },
+  { unit: 'kpeb', pebFactor: 3 },
+  { unit: 'Mpeb', pebFactor: 6 },
+  { unit: 'Gpeb', pebFactor: 9 },
+  { unit: 'ston', pebFactor: 9 },
+  { unit: 'Ston', pebFactor: 9 },
+  { unit: 'uKLAY', pebFactor: 12 },
+  { unit: 'mKLAY', pebFactor: 15 },
+  { unit: 'KLAY', pebFactor: 18 },
+  { unit: 'kKLAY', pebFactor: 21 },
+  { unit: 'MKLAY', pebFactor: 24 },
+  { unit: 'GKLAY', pebFactor: 27 },
+  { unit: 'TKLAY', pebFactor: 30 },
+];
+
+function getFactor(unit: string): number {
+  for ( let i=0; i < KlayUnit.length ; i++ ) {
+    if ( KlayUnit[i].unit === unit) {
+      return KlayUnit[i].pebFactor;
+    }
+  }
+  assertArgument(false, "invalid unit", "unit", unit);
+  return 0;
+}
+
+type Numeric = number | bigint;
+
+/**
+*  Converts %%value%% into a //decimal string//, assuming %%unit%% decimal
+*  places. The %%unit%% may be the number of decimal places or the name of
+*  a unit (e.g. ``"gpeb"`` for 9 decimal places).
+*
+*/
+export function formatKlaytnUnits(value: BigNumberish, unit?: string | Numeric): string {
+  let decimals = 18;
+  if (typeof(unit) === "string") {
+      const index = names.indexOf(unit);
+      assertArgument(index >= 0, "invalid unit", "unit", unit);
+      decimals = getFactor(unit);
+  } else if (unit != null) {
+      decimals = getNumber(unit, "unit");
+  }
+
+  // @ts-ignore
+  return FixedNumber.fromValue( BigNumber.from(value), decimals, { decimals, width: 512 }).toString();
+}
+
+/**
+*  Converts the //decimal string// %%value%% to a BigInt, assuming
+*  %%unit%% decimal places. The %%unit%% may the number of decimal places
+*  or the name of a unit (e.g. ``"gpeb"`` for 9 decimal places).
+*/
+export function parseKlaytnUnits(value: string, unit?: string | Numeric): bigint {
+  assertArgument(typeof(value) === "string", "value must be a string", "value", value);
+
+  let decimals = 18;
+  if (typeof(unit) === "string") {
+      const index = names.indexOf(unit);
+      assertArgument(index >= 0, "invalid unit", "unit", unit);
+      decimals = getFactor( unit );
+  } else if (unit != null) {
+      decimals = getNumber(unit, "unit");
+  }
+
+  // @ts-ignore
+  return FixedNumber.fromString(value, { decimals, width: 512 }).value;
+}
+
+/**
+*  Converts %%value%% into a //decimal string// using 18 decimal places.
+*/
+export function formatKlaytn(peb: BigNumberish): string {
+  return formatKlaytnUnits(peb, 18);
+}
+
+/**
+*  Converts the //decimal string// %%ether%% to a BigInt, using 18
+*  decimal places.
+*/
+export function parseKlaytn(klay: string): bigint {
+  return parseKlaytnUnits(klay, 18);
+}
+
+function assertArgument( check: boolean, message: string, code: string, info: any) {
+  if ( check == false )
+    throw new Error( "message: " + message + ", code: " + code + ", info: " + info );
+}
+
+// IEEE 754 support 53-bits of mantissa
+const maxValue = 0x1fffffffffffff;
+
+/**
+ *  Gets a //number// from %%value%%. If it is an invalid value for
+ *  a //number//, then an ArgumentError will be thrown for %%name%%.
+ */
+export function getNumber(value: BigNumberish, name?: string): any {
+  switch (typeof(value)) {
+      case "bigint":
+          assertArgument(value >= -maxValue && value <= maxValue, "overflow", name || "value", value);
+          return Number(value);
+      case "number":
+          assertArgument(Number.isInteger(value), "underflow", name || "value", value);
+          assertArgument(value >= -maxValue && value <= maxValue, "overflow", name || "value", value);
+          return value;
+      case "string":
+          try {
+              if (value === "") { throw new Error("empty string"); }
+              return getNumber(BigInt(value), name);
+          } catch(e: any) {
+              assertArgument(false, `invalid numeric string: ${ e.message }`, name || "value", value);
+          }
+  }
+  assertArgument(false, "invalid numeric value", name || "value", value);
+}
+

--- a/ethers-ext/src/core/util.ts
+++ b/ethers-ext/src/core/util.ts
@@ -78,7 +78,6 @@ export enum Klaytn {
   AccountKeyRoleBased = 0x05
 };
 
-
 // For Klay unit
 // https://docs.klaytn.foundation/content/klaytn/design/klaytn-native-coin-klay
 // https://docs.ethers.org/v5/api/utils/display-logic/#display-logic--units
@@ -150,7 +149,7 @@ export function formatKlaytnUnits(value: BigNumberish, unit?: string | Numeric):
 *  %%unit%% decimal places. The %%unit%% may the number of decimal places
 *  or the name of a unit (e.g. ``"gpeb"`` for 9 decimal places).
 */
-export function parseKlaytnUnits(value: string, unit?: string | Numeric): bigint {
+export function parseKlaytnUnits(value: string, unit?: string | Numeric): bigint{
   assertArgument(typeof(value) === "string", "value must be a string", "value", value);
 
   let decimals = 18;
@@ -163,7 +162,7 @@ export function parseKlaytnUnits(value: string, unit?: string | Numeric): bigint
   }
 
   // @ts-ignore
-  return FixedNumber.fromString(value, { decimals, width: 512 }).value;
+  return FixedNumber.fromString(value, { decimals, width: 512 });
 }
 
 /**

--- a/ethers-ext/src/core/util.ts
+++ b/ethers-ext/src/core/util.ts
@@ -80,16 +80,15 @@ export enum Klaytn {
 
 
 // For Klay unit
+// https://docs.klaytn.foundation/content/klaytn/design/klaytn-native-coin-klay
+// https://docs.ethers.org/v5/api/utils/display-logic/#display-logic--units
 // https://github.com/ethers-io/ethers.js/blob/main/src.ts/utils/units.ts 
-// https://github.com/klaytn/caver-js/blob/82ba48c52bd3fc2738ccba40f67a4bd0f206822a/packages/caver-utils/src/index.js#L241C1-L420C2
-
 const names = [
   "peb",
   "kpeb",
   "Mpeb",
   "Gpeb",
   "ston",
-  "Ston",
   "uKLAY",
   "mKLAY",
   "KLAY",
@@ -105,7 +104,6 @@ const KlayUnit = [
   { unit: 'Mpeb', pebFactor: 6 },
   { unit: 'Gpeb', pebFactor: 9 },
   { unit: 'ston', pebFactor: 9 },
-  { unit: 'Ston', pebFactor: 9 },
   { unit: 'uKLAY', pebFactor: 12 },
   { unit: 'mKLAY', pebFactor: 15 },
   { unit: 'KLAY', pebFactor: 18 },
@@ -171,7 +169,7 @@ export function parseKlaytnUnits(value: string, unit?: string | Numeric): bigint
 /**
 *  Converts %%value%% into a //decimal string// using 18 decimal places.
 */
-export function formatKlaytn(peb: BigNumberish): string {
+export function formatKLAY(peb: BigNumberish): string {
   return formatKlaytnUnits(peb, 18);
 }
 
@@ -179,7 +177,7 @@ export function formatKlaytn(peb: BigNumberish): string {
 *  Converts the //decimal string// %%ether%% to a BigInt, using 18
 *  decimal places.
 */
-export function parseKlaytn(klay: string): bigint {
+export function parseKLAY(klay: string): bigint {
   return parseKlaytnUnits(klay, 18);
 }
 

--- a/ethers-ext/src/core/util.ts
+++ b/ethers-ext/src/core/util.ts
@@ -148,10 +148,11 @@ export function formatKlaytnUnits(value: BigNumberish, unit?: string | Numeric):
 
 /**
 *  Converts the //decimal string// %%value%% to a BigInt, assuming
-*  %%unit%% decimal places. The %%unit%% may the number of decimal places
-*  or the name of a unit (e.g. ``"gpeb"`` for 9 decimal places).
+*  %%unit%% decimal places. Original Ethers function returns FixedNumber.value, 
+*  but we changed to return BigNumber. The %%unit%% may the number of decimal places
+*  or the name of a unit (e.g. ``"gpeb"`` for 9 decimal places). 
 */
-export function parseKlaytnUnits(value: string, unit?: string | Numeric): bigint{
+export function parseKlaytnUnits(value: string, unit?: string | Numeric): bigint {
   assertArgument(typeof(value) === "string", "value must be a string", "value", value);
 
   let decimals = 18;
@@ -162,10 +163,10 @@ export function parseKlaytnUnits(value: string, unit?: string | Numeric): bigint
       decimals = getNumber(unit, "unit");
   }
 
-  // Original Ethers function returns FixedNumber.value, but we need to return BigNumber.
+  
   // https://github.com/ethers-io/ethers.js/blob/3c17cf56b5164236108269ac1e36d66e2843cd1e/src.ts/utils/units.ts#L75
   // @ts-ignore
-  return FixedNumber.fromString(value, { decimals, width: 512 });
+  return BigNumber.from(FixedNumber.fromString(value, { decimals, width: 512 }));
 }
 
 /**

--- a/ethers-ext/src/ethers/accountStore.ts
+++ b/ethers-ext/src/ethers/accountStore.ts
@@ -11,18 +11,29 @@ export class Accounts {
 
     public wallets : Wallet[];
 
-    constructor( provider: JsonRpcProvider, list: [[string, string?]] ) {
+    constructor( provider: JsonRpcProvider, list: [[string, string?]] | Wallet[]) {
         this.wallets = []
 
         for ( let i=0 ; i<list.length ; i++ ) {
-            if ( list[i].length == 1 ) {
-                this.add( [ list[i][0] ], provider );
-            } else if ( list[i].length == 2 ) {
-                this.add( [ list[i][0], list[i][1] ], provider ); 
+            if ( list[i] instanceof Wallet ) { 
+                // @ts-ignore
+                this.wallets.push( list[i] );
+            } else if ( Array.isArray(list[i]) ) {
+                // @ts-ignore
+                if ( list[i].length == 1 ) {
+                    // @ts-ignore
+                    this.add( [ list[i][0] ], provider );
+                // @ts-ignore
+                } else if ( list[i].length == 2 ) {
+                    // @ts-ignore
+                    this.add( [ list[i][0], list[i][1] ], provider ); 
+                } else {
+                    throw new Error(`Input has to be the array of [address, privateKey] or [privateKey]`);
+                }
             } else {
-                throw new Error(`Input has to be the array of [address, privateKey] or [privateKey]`);
+                throw new Error(`Input has to be Wallet, [address, privateKey], or [privateKey]`);
             }
-        }
+        }            
     }
 
     async add( account: [string, string?], provider: JsonRpcProvider ) : Promise<boolean> {
@@ -127,7 +138,7 @@ export class AccountStore {
     public accountInfos: AccountInfo[] | undefined;
     private signableKeyList: string[] = []; 
     
-    async refresh( provider: JsonRpcProvider, list: [[string, string?]]) {
+    async refresh( provider: JsonRpcProvider, list: [[string, string?]] | Wallet[]) {
         this.provider = provider;
 
         if ( this.accounts != undefined ) {

--- a/ethers-ext/src/index.ts
+++ b/ethers-ext/src/index.ts
@@ -1,4 +1,4 @@
 export { KlaytnTxFactory, AccountKeyFactory } from "./core";
-export { Klaytn } from "./core/util"
+export { Klaytn, formatKlaytnUnits, formatKLAY, parseKlaytnUnits, parseKLAY } from "./core/util"
 export { Wallet, JsonRpcProvider, Accounts, AccountStore } from "./ethers";
 export { verifyMessageAsKlaytnAccountKey } from "./ethers/signer";

--- a/ethers-ext/src/index.ts
+++ b/ethers-ext/src/index.ts
@@ -1,4 +1,4 @@
 export { KlaytnTxFactory, AccountKeyFactory } from "./core";
-export { Klaytn, formatKlaytnUnits, formatKLAY, parseKlaytnUnits, parseKLAY } from "./core/util"
+export { Klaytn, formatKlaytnUnits, formatKlay, parseKlaytnUnits, parseKlay } from "./core/util"
 export { Wallet, JsonRpcProvider, Accounts, AccountStore } from "./ethers";
 export { verifyMessageAsKlaytnAccountKey } from "./ethers/signer";

--- a/ethers-ext/src/index.ts
+++ b/ethers-ext/src/index.ts
@@ -1,3 +1,4 @@
 export { KlaytnTxFactory, AccountKeyFactory } from "./core";
+export { Klaytn } from "./core/util"
 export { Wallet, JsonRpcProvider, Accounts, AccountStore } from "./ethers";
 export { verifyMessageAsKlaytnAccountKey } from "./ethers/signer";

--- a/ethers-ext/src/index.ts
+++ b/ethers-ext/src/index.ts
@@ -1,4 +1,4 @@
 export { KlaytnTxFactory, AccountKeyFactory } from "./core";
-export { Klaytn, formatKlaytnUnits, formatKlay, parseKlaytnUnits, parseKlay } from "./core/util"
+export { TxType, AccountKeyType, formatKlaytnUnits, formatKlay, parseKlaytnUnits, parseKlay } from "./core/util"
 export { Wallet, JsonRpcProvider, Accounts, AccountStore } from "./ethers";
 export { verifyMessageAsKlaytnAccountKey } from "./ethers/signer";


### PR DESCRIPTION
- Add Klaytn Tx & AccountKey type enumeration 
- Update existing examples using this enumeration
- Add Klaytn unit (pep, kpep, Mpep, Gpep, ston, KLAY ... ) converting functions & its examples
- Update AccountStore's refresh function for input parameters (Wallet, [addr, privatekey], [privatekey]) 