### PR TITLE
ethers: Remove Wallet dynamicUpdateWalletAPI

### DIFF
--- a/ethers-ext/.eslintrc.js
+++ b/ethers-ext/.eslintrc.js
@@ -30,6 +30,7 @@ module.exports = {
     "no-unneeded-ternary": "warn",
     "yoda": "warn",
 
+    "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/ban-ts-comment": "off",
 


### PR DESCRIPTION
This dynamic extension mechanism does not work as of now.
I propose to remove the feature until we know a clean solution or choose not to implement a dynamic extension.


Below code fails because `ew.populateTransaction` calls the vanilla ethers method.
```js
const ethers = require("ethers");
const { Wallet, JsonRpcProvider } = require("@klaytn/ethers-ext");

async function main() {
    var provider = new JsonRpcProvider("https://public-en-baobab.klaytn.net");
    var key = "0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8";
    var addr = '0xa2a8854b1802d8cd5de631e690817c253d6a9153';

    var tx = { type: 9, from: addr, to: addr, feePayer: addr, value: 0 };

    var kw = new Wallet(key, provider, true);
    var kt = await kw.populateTransaction(tx);
    console.log(kt);

    var ew = new ethers.Wallet(key, provider);
    var et = await ew.populateTransaction(tx);
    console.log(et);
}
main();
```