### PR TITLE
v4 keystore support example

### DIFF
--- a/ethers-ext/src/core/index.ts
+++ b/ethers-ext/src/core/index.ts
@@ -1,5 +1,6 @@
 export { KlaytnTx, KlaytnTxFactory } from "./klaytn_tx";
 export { AccountKey, AccountKeyFactory } from "./accountKey";
+export { decryptJsonWallet } from "./keystore";
 
 /* eslint-disable import/order */
 import { KlaytnTxFactory } from "./klaytn_tx";

--- a/ethers-ext/src/core/keystore.ts
+++ b/ethers-ext/src/core/keystore.ts
@@ -1,0 +1,202 @@
+import aes from "aes-js";
+import scrypt from "scrypt-js";
+import {_KeystoreAccount, KeystoreAccount} from "@ethersproject/json-wallets/lib/keystore";
+import {looseArrayify, searchPath, getPassword} from "@ethersproject/json-wallets/lib/utils";
+import {arrayify, Bytes, computeAddress, concat, entropyToMnemonic, hexlify, keccak256, ProgressCallback} from "ethers/lib/utils";
+import {defaultPath, HDNode} from "@ethersproject/hdnode";
+import {Logger } from "@ethersproject/logger";
+import {version} from "@ethersproject/json-wallets/lib/_version"
+import { ExternallyOwnedAccount } from "@ethersproject/abstract-signer";
+import { pbkdf2 as _pbkdf2 } from "@ethersproject/pbkdf2";
+import {isCrowdsaleWallet,decryptCrowdsale, isKeystoreWallet} from "@ethersproject/json-wallets"
+const logger = Logger.from(version)
+
+export function decryptJsonWallet(json: string, password: Bytes | string, progressCallback?: ProgressCallback): Promise<ExternallyOwnedAccount> {
+  if (isCrowdsaleWallet(json)) {
+      if (progressCallback) { progressCallback(0); }
+      const account = decryptCrowdsale(json, password)
+      if (progressCallback) { progressCallback(1); }
+      return Promise.resolve(account);
+  }
+
+  if (isKeystoreWallet(json)) {
+      return decrypt(json, password, progressCallback);
+  }
+
+  return Promise.reject(new Error("invalid JSON wallet"));
+}
+
+export function decryptJsonWalletSync(json: string, password: Bytes | string): ExternallyOwnedAccount {
+  if (isCrowdsaleWallet(json)) {
+      return decryptCrowdsale(json, password)
+  }
+
+  if (isKeystoreWallet(json)) {
+      return decryptSync(json, password);
+  }
+
+  throw new Error("invalid JSON wallet");
+}
+
+export function decryptSync(json: string, password: Bytes | string): KeystoreAccount {
+  const data = JSON.parse(json);
+  
+  const key = _computeKdfKey(data, password, pbkdf2Sync, scrypt.syncScrypt);
+  return _getAccount(data, key);
+}
+
+export async function decrypt(json: string, password: Bytes | string, progressCallback?: ProgressCallback): Promise<KeystoreAccount> {
+  const data = JSON.parse(json);
+
+  const key = await _computeKdfKey(data, password, pbkdf2, scrypt.scrypt, progressCallback);
+  return _getAccount(data, key);
+}
+
+function _decrypt(data: any, key: Uint8Array, ciphertext: Uint8Array): Uint8Array {
+    const cipher = searchPath(data, "crypto/cipher");
+    if (cipher === "aes-128-ctr") {
+        const iv = looseArrayify(searchPath(data, "crypto/cipherparams/iv"))
+        const counter = new aes.Counter(iv);
+
+        const aesCtr = new aes.ModeOfOperation.ctr(key, counter);
+
+        return arrayify(aesCtr.decrypt(ciphertext));
+    }
+    //@ts-ignore
+    return null;
+}
+
+function _getAccount(data: any, key: Uint8Array): KeystoreAccount {
+  const ciphertext = looseArrayify(searchPath(data, "crypto/ciphertext"));
+
+  const computedMAC = hexlify(keccak256(concat([key.slice(16, 32), ciphertext]))).substring(2);
+  if (computedMAC !== searchPath(data, "crypto/mac").toLowerCase()) {
+    throw new Error("invalid password");
+  }
+
+  const privateKey = _decrypt(data, key.slice(0, 16), ciphertext);
+
+  if (!privateKey) {
+    logger.throwError("unsupported cipher", Logger.errors.UNSUPPORTED_OPERATION, {
+      operation: "decrypt"
+    });
+  }
+
+  const mnemonicKey = key.slice(32, 64);
+
+  // const address = computeAddress(privateKey);
+  // if (data.address) {
+  //   let check = data.address.toLowerCase();
+  //   if (check.substring(0, 2) !== "0x") { check = "0x" + check; }
+
+  //   if (getAddress(check) !== address) {
+  //     throw new Error("address mismatch");
+  //   }
+  // }
+
+  const account: _KeystoreAccount = {
+    _isKeystoreAccount: true,
+    address: data.address,
+    privateKey: hexlify(privateKey)
+  };
+
+  // Version 0.1 x-ethers metadata must contain an encrypted mnemonic phrase
+  if (searchPath(data, "x-ethers/version") === "0.1") {
+    const mnemonicCiphertext = looseArrayify(searchPath(data, "x-ethers/mnemonicCiphertext"));
+    const mnemonicIv = looseArrayify(searchPath(data, "x-ethers/mnemonicCounter"));
+
+    const mnemonicCounter = new aes.Counter(mnemonicIv);
+    const mnemonicAesCtr = new aes.ModeOfOperation.ctr(mnemonicKey, mnemonicCounter);
+
+    const path = searchPath(data, "x-ethers/path") || defaultPath;
+    const locale = searchPath(data, "x-ethers/locale") || "en";
+
+    const entropy = arrayify(mnemonicAesCtr.decrypt(mnemonicCiphertext));
+
+    try {
+      const mnemonic = entropyToMnemonic(entropy, locale);
+      //@ts-ignore
+      const node = HDNode.fromMnemonic(mnemonic, null, locale).derivePath(path);
+
+      if (node.privateKey != account.privateKey) {
+        throw new Error("mnemonic mismatch");
+      }
+
+      account.mnemonic = node.mnemonic;
+    } catch (error) {
+      // If we don't have the locale wordlist installed to
+      // read this mnemonic, just bail and don't set the
+      // mnemonic
+      //@ts-ignore
+      if (error.code !== Logger.errors.INVALID_ARGUMENT || error.argument !== "wordlist") {
+        throw error;
+      }
+    }
+  }
+
+  return new KeystoreAccount(account);
+}
+
+type ScryptFunc<T> = (pw: Uint8Array, salt: Uint8Array, n: number, r: number, p: number, dkLen: number, callback?: ProgressCallback) => T;
+type Pbkdf2Func<T> = (pw: Uint8Array, salt: Uint8Array, c: number, dkLen: number, prfFunc: string) => T;
+
+function pbkdf2Sync(passwordBytes: Uint8Array, salt: Uint8Array, count: number, dkLen: number, prfFunc: string): Uint8Array {
+    return arrayify(_pbkdf2(passwordBytes, salt, count, dkLen, prfFunc));
+}
+
+function pbkdf2(passwordBytes: Uint8Array, salt: Uint8Array, count: number, dkLen: number, prfFunc: string): Promise<Uint8Array> {
+    return Promise.resolve(pbkdf2Sync(passwordBytes, salt, count, dkLen, prfFunc));
+}
+
+function _computeKdfKey<T>(data: any, password: Bytes | string, pbkdf2Func: Pbkdf2Func<T>, scryptFunc: ScryptFunc<T>, progressCallback?: ProgressCallback): T {
+    const passwordBytes = getPassword(password);
+
+    const kdf = searchPath(data, "crypto/kdf");
+
+    if (kdf && typeof(kdf) === "string") {
+        const throwError = function(name: string, value: any): never {
+            return logger.throwArgumentError("invalid key-derivation function parameters", name, value);
+        }
+
+        if (kdf.toLowerCase() === "scrypt") {
+            const salt = looseArrayify(searchPath(data, "crypto/kdfparams/salt"));
+            const N = parseInt(searchPath(data, "crypto/kdfparams/n"));
+            const r = parseInt(searchPath(data, "crypto/kdfparams/r"));
+            const p = parseInt(searchPath(data, "crypto/kdfparams/p"));
+
+            // Check for all required parameters
+            if (!N || !r || !p) { throwError("kdf", kdf); }
+
+            // Make sure N is a power of 2
+            if ((N & (N - 1)) !== 0) { throwError("N", N); }
+
+            const dkLen = parseInt(searchPath(data, "crypto/kdfparams/dklen"));
+            if (dkLen !== 32) { throwError("dklen", dkLen); }
+
+            return scryptFunc(passwordBytes, salt, N, r, p, 64, progressCallback);
+
+        } else if (kdf.toLowerCase() === "pbkdf2") {
+
+            const salt = looseArrayify(searchPath(data, "crypto/kdfparams/salt"));
+
+            let prfFunc: string = "";
+            const prf = searchPath(data, "crypto/kdfparams/prf");
+            if (prf === "hmac-sha256") {
+                prfFunc = "sha256";
+            } else if (prf === "hmac-sha512") {
+                prfFunc = "sha512";
+            } else {
+                throwError("prf", prf);
+            }
+
+            const count = parseInt(searchPath(data, "crypto/kdfparams/c"));
+
+            const dkLen = parseInt(searchPath(data, "crypto/kdfparams/dklen"));
+            if (dkLen !== 32) { throwError("dklen", dkLen); }
+
+            return pbkdf2Func(passwordBytes, salt, count, dkLen, prfFunc);
+        }
+    }
+
+    return logger.throwArgumentError("unsupported key-derivation function", "kdf", kdf);
+}

--- a/ethers-ext/test.js
+++ b/ethers-ext/test.js
@@ -1,0 +1,80 @@
+const keystore = require("./dist/src/core/keystore")
+
+const v4Multisig = {
+    "version": 4,
+    "id": "54d86643-64c9-4b17-b220-ee8ac8e37a38",
+    "address": "0xea27c011093b3ab28ae932905e058b0eba503490",
+    "keyring": [
+      {
+        "ciphertext": "713589f0bc2049b05da09460a0daa84ebe616fa6c8631a57ea4a2c22128e5889",
+        "cipherparams": {
+          "iv": "708114437171614deb96a8fc67caf48c"
+        },
+        "cipher": "aes-128-ctr",
+        "kdf": "scrypt",
+        "kdfparams": {
+          "dklen": 32,
+          "salt": "84f2b9b74bc32d3b2582203c9059445af8cd15b2f40eb8e35c2a82dd0da06904",
+          "n": 4096,
+          "r": 8,
+          "p": 1
+        },
+        "mac": "3a801695ece35aa5613a2920e4a2f40d52c5fac10e836c6a90ca6627d389c9c0"
+      },
+      {
+        "ciphertext": "db7479883998e423b9aeaed224e6e513a7ae6b330d44a3c7a8001ecef501b227",
+        "cipherparams": {
+          "iv": "c51db43ee7ae7780c6f20b176bd1281f"
+        },
+        "cipher": "aes-128-ctr",
+        "kdf": "scrypt",
+        "kdfparams": {
+          "dklen": 32,
+          "salt": "638066e26ccb00147d07d693ad4363600d76f7681a1a94360d2ae02c32a6105f",
+          "n": 4096,
+          "r": 8,
+          "p": 1
+        },
+        "mac": "9f768ee8fa8c2f87310ee8e2ed5b96d316ff07a057be86ed4d800bf006bfbea4"
+      },
+      {
+        "ciphertext": "4e001471284bd65303196e33fa4c1cfdc9186b2190030635d540e69d25cd4ffa",
+        "cipherparams": {
+          "iv": "5cad01c2ffc3e705c6d473bd9d97622e"
+        },
+        "cipher": "aes-128-ctr",
+        "kdf": "scrypt",
+        "kdfparams": {
+          "dklen": 32,
+          "salt": "9983a8774a7eaf22b547db1f948a4e604b7c07e5d7425069432586901ce6b8b7",
+          "n": 4096,
+          "r": 8,
+          "p": 1
+        },
+        "mac": "5feaee72ba98059cf8021b5fd6d648c80e5b9572f1712ae1f5170397abd10e0d"
+      }
+    ]
+}
+
+function formatToV3(V4Format) {
+    //format check like if (V4Format.version != 4)
+    return V4Format.keyring.map(keyring => {
+        const v3Entry = {
+          address: V4Format.address,
+          id: V4Format.id,
+          version: 3,
+          crypto: keyring
+        };
+        return v3Entry
+    });
+}
+
+async function main() {
+    const keysToDecrypt = formatToV3(v4Multisig)
+    keysToDecrypt.map(async key => {
+        decryptedAccount = keystore.decryptJsonWallet(JSON.stringify(key), "Hahaa")
+        console.log(await decryptedAccount)
+    })
+}
+
+main()


### PR DESCRIPTION
- keystore v4 format support example
  - parse multisig that includes 3 keys into multiple json for each key
  - decrypt the keys
  - took the code from Ethers to bypass the address comparison part.