### PR TITLE
feat: add decrypt function into ether ext

### DIFF
--- a/ethers-ext/package-lock.json
+++ b/ethers-ext/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@klaytn/ethers-ext",
-  "version": "0.9.1-beta",
+  "version": "0.9.3-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@klaytn/ethers-ext",
-      "version": "0.9.1-beta",
+      "version": "0.9.3-beta",
       "license": "MIT",
       "dependencies": {
+        "@klaytn/ethers-ext": "^0.9.3-beta",
         "@klaytn/web3rpc": "^0.9.0",
         "lodash": "^4.17.21"
       },
@@ -1392,6 +1393,18 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@klaytn/ethers-ext": {
+      "version": "0.9.3-beta",
+      "resolved": "https://registry.npmjs.org/@klaytn/ethers-ext/-/ethers-ext-0.9.3-beta.tgz",
+      "integrity": "sha512-As3iP/KhxG6+EVbnEln4QtF5A/M5HI7uGFzbFXFSQCd4LpQlLovQcI31fjaD9tgCw4DA4agAqHNcnBPBnX6j6A==",
+      "dependencies": {
+        "@klaytn/web3rpc": "^0.9.0",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "ethers": "^5.7.2"
       }
     },
     "node_modules/@klaytn/web3rpc": {

--- a/ethers-ext/package.json
+++ b/ethers-ext/package.json
@@ -20,10 +20,13 @@
     "ethers": "^5.7.2"
   },
   "devDependencies": {
+    "@types/aes-js": "^3.1.1",
+    "@types/bn.js": "^5.1.1",
     "@types/chai": "^4.3.4",
     "@types/chai-as-promised": "^7.1.5",
     "@types/lodash": "^4.14.192",
     "@types/mocha": "^10.0.1",
+    "@types/uuid": "^9.0.3",
     "@typescript-eslint/eslint-plugin": "^6.1.0",
     "chai": "^4.3.7",
     "chai-as-promised": "^7.1.1",
@@ -34,7 +37,11 @@
     "typescript": "^5.0.4"
   },
   "dependencies": {
+    "@klaytn/ethers-ext": "^0.9.3-beta",
     "@klaytn/web3rpc": "^0.9.0",
-    "lodash": "^4.17.21"
+    "bn.js": "^5.2.1",
+    "eth-lib": "^0.1.29",
+    "lodash": "^4.17.21",
+    "uuid": "^9.0.1"
   }
 }

--- a/ethers-ext/src/ethers/keystore/decrypt.ts
+++ b/ethers-ext/src/ethers/keystore/decrypt.ts
@@ -1,0 +1,82 @@
+import { Bytes } from "@ethersproject/bytes";
+import { decryptKeystoreSync } from "@ethersproject/json-wallets";
+import * as _ from "lodash";
+import { IKeyStore } from ".";
+
+// Modified from KeystoreAccount at @ethersproject/json-wallets/src.ts/keystore.ts
+interface KeystoreAccountList {
+  address: string;
+  privateKeys: string[];
+}
+
+function decryptKey(crypto: any, password: Bytes | string): string {
+  const datav3 = {
+    version: 3,
+    crypto: crypto,
+  };
+  const jsonv3 = JSON.stringify(datav3);
+  const ka = decryptKeystoreSync(jsonv3, password);
+  return ka.privateKey;
+}
+
+/**
+ * Decrypts the Klaytn KIP-3 (https://github.com/klaytn/kips/blob/main/KIPs/kip-3.md) JSON wallet.
+ * KIP-3 v4 wallet comes in one of three shapes:
+ * - An array of one key = [key]
+ * - An array of multiple keys = [key, key, key]
+ *
+ * Regardless of how they are organized, each encrytped key object is decrypted
+ * then returned in a flattend array of private keys.
+ *
+ */
+function decryptKeystoreV4(json: string, password: Bytes | string): KeystoreAccountList {
+  const data: IKeyStore = JSON.parse(json);
+  const privateKeys: string[] = [];
+
+  if (!_.has(data, "keyring")) {
+    throw new Error("invalid JSON wallet v4 (KIP-3)");
+  }
+  if (!_.isArray(data.keyring)) {
+    throw new Error("invalid JSON wallet v4 (KIP-3)");
+  }
+
+  _.each(data.keyring, (keyOrKeys: any) => {
+    if (!_.isArray(keyOrKeys)) {
+      const key: any = keyOrKeys;
+      privateKeys.push(decryptKey(key, password));
+    } else {
+      const keys: any[] = keyOrKeys;
+      _.each(keys, (key: any) => {
+        privateKeys.push(decryptKey(key, password));
+      });
+    }
+  });
+
+  return {
+    address: _.toString(data.address),
+    privateKeys: privateKeys,
+  };
+}
+
+/**
+ * Decrypts a JSON keystore wallet and returns the account details containing
+ * the account address and the list of private keys.
+ * It accepts a Crowdsale wallet, V3 keystore, and KIP-3 V4 keystore wallets.
+ *
+ */
+export function decryptKeystoreListSync(json: string, password: Bytes | string): KeystoreAccountList {
+  const data: IKeyStore = JSON.parse(json);
+  const version = data.version;
+
+  // decryptKeystoreV4 handles v4 (KIP-3) wallets.
+  if (version == 4) {
+    return decryptKeystoreV4(json, password);
+  }
+
+  // decryptKeystoreSync handles v3 and Crowdsale wallets.
+  const ka = decryptKeystoreSync(json, password);
+  return {
+    address: ka.address,
+    privateKeys: [ka.privateKey],
+  };
+}

--- a/ethers-ext/src/ethers/keystore/index.ts
+++ b/ethers-ext/src/ethers/keystore/index.ts
@@ -1,0 +1,2 @@
+export { decryptKeystoreListSync } from "./decrypt";
+export * from "./type";

--- a/ethers-ext/src/ethers/keystore/type.ts
+++ b/ethers-ext/src/ethers/keystore/type.ts
@@ -1,0 +1,33 @@
+
+
+export interface IKeyStore {
+  address: string,
+  id: string,
+  version: number,
+  keyring?: Keyring[] | Keyring [][],
+  crypto?: Keyring,
+
+}
+export interface Keyring {
+  cipher: string,
+  cipherparams: CipherParams,
+  ciphertext: string,
+  kdf: string,
+  kdfparams: KdfParam,
+  mac?: string
+}
+
+interface CipherParams {
+  iv: string
+}
+
+export interface KdfParam {
+  salt: string,
+  n: number,
+  dklen: number,
+  p: number,
+  r: number,
+  c?: number,
+  prf?: string,
+}
+

--- a/ethers-ext/src/ethers/signer.ts
+++ b/ethers-ext/src/ethers/signer.ts
@@ -8,6 +8,7 @@ import _ from "lodash";
 import { KlaytnTxFactory } from "../core";
 import { encodeTxForRPC, objectFromRLP } from "../core/klaytn_tx";
 import { HexStr } from "../core/util";
+import { decryptKeystoreListSync } from "./keystore";
 
 import { JsonRpcProvider } from "./provider";
 
@@ -272,6 +273,16 @@ export class Wallet extends EthersWallet {
     } else {
       throw new Error("Klaytn typed transaction can only be broadcasted to a Klaytn JSON-RPC server");
     }
+  }
+
+  static fromEncryptedJsonSync(json: string, password: string | Bytes): Wallet {
+    const { address, privateKeys } = decryptKeystoreListSync(json, password);
+    return new Wallet(address, privateKeys[0]);
+  }
+
+  static fromEncryptedJsonListSync(json: string, password: string | Bytes): Wallet[] {
+    const { address, privateKeys } = decryptKeystoreListSync(json, password);
+    return _.map(privateKeys, (privateKey) => new Wallet(address, privateKey));
   }
 }
 

--- a/ethers-ext/test/ethers/decrypt_encrypt.spec.ts
+++ b/ethers-ext/test/ethers/decrypt_encrypt.spec.ts
@@ -1,0 +1,198 @@
+import chai from "chai";
+
+import * as keystore from "../../src/ethers/keystore";
+
+const assert = chai.assert;
+const expect = chai.expect;
+
+describe("decrypt and encrypt", async () => {
+  describe("decrypt ", async () => {
+    async function testOK(res: any) {
+      assert.isDefined(res);
+    }
+
+    it("decrypt multiple keyring", async () => {
+      const decryptData = await keystore.decryptKeystoreListSync(JSON.stringify({
+        "version": 4,
+        "id": "54d86643-64c9-4b17-b220-ee8ac8e37a38",
+        "address": "0xea27c011093b3ab28ae932905e058b0eba503490",
+        "keyring": [
+          {
+            "ciphertext": "713589f0bc2049b05da09460a0daa84ebe616fa6c8631a57ea4a2c22128e5889",
+            "cipherparams": {
+              "iv": "708114437171614deb96a8fc67caf48c"
+            },
+            "cipher": "aes-128-ctr",
+            "kdf": "scrypt",
+            "kdfparams": {
+              "dklen": 32,
+              "salt": "84f2b9b74bc32d3b2582203c9059445af8cd15b2f40eb8e35c2a82dd0da06904",
+              "n": 4096,
+              "r": 8,
+              "p": 1
+            },
+            "mac": "3a801695ece35aa5613a2920e4a2f40d52c5fac10e836c6a90ca6627d389c9c0"
+          },
+          {
+            "ciphertext": "db7479883998e423b9aeaed224e6e513a7ae6b330d44a3c7a8001ecef501b227",
+            "cipherparams": {
+              "iv": "c51db43ee7ae7780c6f20b176bd1281f"
+            },
+            "cipher": "aes-128-ctr",
+            "kdf": "scrypt",
+            "kdfparams": {
+              "dklen": 32,
+              "salt": "638066e26ccb00147d07d693ad4363600d76f7681a1a94360d2ae02c32a6105f",
+              "n": 4096,
+              "r": 8,
+              "p": 1
+            },
+            "mac": "9f768ee8fa8c2f87310ee8e2ed5b96d316ff07a057be86ed4d800bf006bfbea4"
+          },
+          {
+            "ciphertext": "4e001471284bd65303196e33fa4c1cfdc9186b2190030635d540e69d25cd4ffa",
+            "cipherparams": {
+              "iv": "5cad01c2ffc3e705c6d473bd9d97622e"
+            },
+            "cipher": "aes-128-ctr",
+            "kdf": "scrypt",
+            "kdfparams": {
+              "dklen": 32,
+              "salt": "9983a8774a7eaf22b547db1f948a4e604b7c07e5d7425069432586901ce6b8b7",
+              "n": 4096,
+              "r": 8,
+              "p": 1
+            },
+            "mac": "5feaee72ba98059cf8021b5fd6d648c80e5b9572f1712ae1f5170397abd10e0d"
+          }
+        ]
+      }), "Hahaa");
+      testOK(decryptData);
+    });
+
+    it("decrypt role base keyring", async () => {
+      const decryptData = await keystore.decryptKeystoreListSync(JSON.stringify({
+        "version": 4,
+        "id": "c903083c-a42c-4774-8cea-f4c5a7962732",
+        "address": "0x17226c9b4e130551c258eb7b1cdc927c13998cd6",
+        "keyring": [
+          [
+            {
+              "ciphertext": "e341cf7fb7f19031374a61abb7f2d5d643ca6408bc1e8398de4ac9dd3e0697c1",
+              "cipherparams": { "iv": "fb46dcc6521dc880b54f78891b479dc3" },
+              "cipher": "aes-128-ctr",
+              "kdf": "scrypt",
+              "kdfparams": {
+                "dklen": 32,
+                "salt": "f48e0cd5625e55f62d831d12378fad49ff1a715d490e5996d4a5a275f6a277c2",
+                "n": 4096,
+                "r": 8,
+                "p": 1
+              },
+              "mac": "a03c2c7b6dff1ad793d2ede88a679d82c734e266fcd40bb875d765e50955edb1"
+            },
+            {
+              "ciphertext": "668b1a501bbf756016647397078982e6a413a89ed45e8eefd85fb5de52ea5c10",
+              "cipherparams": { "iv": "ad52c6deefe8fd64ae41dd445c966e08" },
+              "cipher": "aes-128-ctr",
+              "kdf": "scrypt",
+              "kdfparams": {
+                "dklen": 32,
+                "salt": "31cd14d3d15f902989db0f0f9b839a420384252eb7daf7c93ebe1c19c11b0ff2",
+                "n": 4096,
+                "r": 8,
+                "p": 1
+              },
+              "mac": "36b47e3cc20656349ca2477b28ed04585eb5712691ea724437d77c7a876faacd"
+            }
+          ],
+          [
+            {
+              "ciphertext": "6b0f9f13bb721aa97e7eda08cbaaeb873c0ec41f1707b5cd58b8f4932b252067",
+              "cipherparams": { "iv": "755c7b650ac384e45d1825f5e73a7bae" },
+              "cipher": "aes-128-ctr",
+              "kdf": "scrypt",
+              "kdfparams": {
+                "dklen": 32,
+                "salt": "b9e984fe8f8630638aefaf7ad4d112c47acb56ef2b36fb2aaaa29cf149ad32f1",
+                "n": 4096,
+                "r": 8,
+                "p": 1
+              },
+              "mac": "f1bec38f3c815f09d4a4244596b0514c0e24a837979f70773b313c3a873d7b9b"
+            }
+          ],
+          [
+            {
+              "ciphertext": "4ca2438538f560570efe0a862d384d6822513d92fb00503b0cf5f20d5ed959af",
+              "cipherparams": { "iv": "6d578196eff13d42a71d61b54a7a56ac" },
+              "cipher": "aes-128-ctr",
+              "kdf": "scrypt",
+              "kdfparams": {
+                "dklen": 32,
+                "salt": "3a5521134feb81fdd47e91165fc391a2f52984a5fd65b15807843b9bbed3d6dc",
+                "n": 4096,
+                "r": 8,
+                "p": 1
+              },
+              "mac": "b7db297d0a8f7e2044ff7a88da3a27af4a4a3489a210b34911a5c87399075873"
+            },
+            {
+              "ciphertext": "91a2d31625ec96fedf58f0ee48987cf39f6e517103b25d5d0afeac5674c62752",
+              "cipherparams": { "iv": "26821451fdaf5215c028eaea756c2797" },
+              "cipher": "aes-128-ctr",
+              "kdf": "scrypt",
+              "kdfparams": {
+                "dklen": 32,
+                "salt": "a958903f3d1e0065bab28a3c5fb14a2b78804869e1f82a93aabecdc4beded6fd",
+                "n": 4096,
+                "r": 8,
+                "p": 1
+              },
+              "mac": "e9e004e310fa6648b82839c8ace5e215866ef4ae6db9a4b9987678de5817d533"
+            },
+            {
+              "ciphertext": "7ab47009dd5762dd10990f5182228a01cfaef00e8b581c51908de296bbb10cb2",
+              "cipherparams": { "iv": "65d76971b9fae3eca2ff18fca4b23097" },
+              "cipher": "aes-128-ctr",
+              "kdf": "scrypt",
+              "kdfparams": {
+                "dklen": 32,
+                "salt": "288ea98e079125403157a9e9f0546cb1db234637e8d65550dfab607e2e65d065",
+                "n": 4096,
+                "r": 8,
+                "p": 1
+              },
+              "mac": "0a60b6b58b7f6bb50aed38b738deffbe7a9cee593829342ebbd57083a80ac508"
+            }
+          ]
+        ]
+      }), "Klaytn");
+      testOK(decryptData);
+    });
+
+
+    it("decrypt single keyring", async () => {
+      const decryptData = await keystore.decryptKeystoreListSync(JSON.stringify({
+        "version": 3,
+        "id": "b5a77191-c954-4ed8-962f-41326e585489",
+        "address": "0x17226c9b4e130551c258eb7b1cdc927c13998cd6",
+        "crypto": {
+          "ciphertext": "e341cf7fb7f19031374a61abb7f2d5d643ca6408bc1e8398de4ac9dd3e0697c1",
+          "cipherparams": { "iv": "fb46dcc6521dc880b54f78891b479dc3" },
+          "cipher": "aes-128-ctr",
+          "kdf": "scrypt",
+          "kdfparams": {
+            "dklen": 32,
+            "salt": "f48e0cd5625e55f62d831d12378fad49ff1a715d490e5996d4a5a275f6a277c2",
+            "n": 4096,
+            "r": 8,
+            "p": 1
+          },
+          "mac": "a03c2c7b6dff1ad793d2ede88a679d82c734e266fcd40bb875d765e50955edb1"
+        },
+      }), "Klaytn");
+      testOK(decryptData);
+    });
+  });
+});


### PR DESCRIPTION
Additional decrypt function into ether-ext
Keystore v4 format support example

- Parse multisig or rolebase key that includes 3 keys into multiple json for each key
- Decrypt the keys
- Took the code from Ethers to bypass the address comparison part.
- Return Wallet instance
