### PR TITLE
ethers: Fix encodeTxForRPC to separately handle 0x and 0x0

### DIFF
--- a/ethers-ext/src/ethers/signer.ts
+++ b/ethers-ext/src/ethers/signer.ts
@@ -143,9 +143,7 @@ export class Wallet extends EthersWallet {
 
     if (!(tx.gasLimit) && !!(tx.to)) {
       if (this.provider instanceof EthersJsonRpcProvider) {
-        const estimateGasAllowedKeys: string[] = [
-          "from", "to", "gasLimit", "gasPrice", "value", "input"];
-        const ttx = encodeTxForRPC(estimateGasAllowedKeys, tx);
+        const ttx = encodeTxForRPC(tx);
 
         const result = await this.provider.send("klay_estimateGas", [ttx]);
         // For the problem that estimateGas does not exactly match,

--- a/ethers-ext/test/core/klaytn_tx.spec.ts
+++ b/ethers-ext/test/core/klaytn_tx.spec.ts
@@ -1,6 +1,8 @@
 import { assert } from "chai";
+import { TransactionRequest } from "@ethersproject/abstract-provider";
 
 import { KlaytnTxFactory } from "../../src/core";
+import { encodeTxForRPC } from "../../src/core/klaytn_tx";
 
 // Non-canonical types, which are common user-supplied values.
 const nonce = 1234;
@@ -71,4 +73,39 @@ describe("TypedTxFactory", () => {
       assert.equal(tx.txHashRLP(), tc.txRLP);
     });
   }
+});
+
+describe("encodeTxForRPC", () => {
+  it("success", () => {
+    let tx: TransactionRequest = {
+      chainId: 42,
+      gasLimit: 0x1111,
+      gasPrice: 0x222,
+      type: 2,
+      maxFeePerGas: 0x33,
+      maxPriorityFeePerGas: 0x4,
+      nonce: 0,
+      value: 0,
+
+      from: "0x00000000000000000000000000000000000000aa",
+      to: "0x00000000000000000000000000000000000000bb",
+      data: "0x",
+    };
+
+    let formatted = encodeTxForRPC(tx);
+    assert.deepEqual(formatted, {
+      chainId: '0x2a',
+      gas: '0x1111',
+      gasPrice: '0x222',
+      type: '0x2',
+      maxFeePerGas: '0x33',
+      maxPriorityFeePerGas: '0x4',
+      nonce: '0x0',
+      value: '0x0',
+
+      from: '0x00000000000000000000000000000000000000aa',
+      to: '0x00000000000000000000000000000000000000bb',
+      data: '0x',
+    });
+  });
 });


### PR DESCRIPTION
When calling some RPCs (eth_estimateGas, eth_call), the transaction arguments must be properly hexlified.
(https://github.com/klaytn/klaytn/blob/dev/api/tx_args.go#L536)

Zero numeric values must be encoded to "0x0" and
Empty bytes and address values must be "0x". 