### PR TITLE
Ethers.js EXT examples for signRecover

### DIFF
--- a/ethers-ext/example/signRecover/1_tx_signRecover_legacy.js
+++ b/ethers-ext/example/signRecover/1_tx_signRecover_legacy.js
@@ -9,12 +9,12 @@ async function main() {
   const provider = new ethers.providers.JsonRpcProvider("https://public-en-baobab.klaytn.net");
   const wallet = new Wallet(senderPriv, provider);
 
-  const recieverAddr = wallet.address;
+  const receiverAddr = wallet.address;
   const senderAddr = wallet.address;
 
   let tx = {
     from: senderAddr,
-    to: recieverAddr,
+    to: receiverAddr,
     value: parseKlay("1"),
   };
 
@@ -33,7 +33,7 @@ async function main() {
   const expandedSig = {
     r: txObj.r,
     s: txObj.s,
-    recoveryParam: 0, // not really sure what this does
+    recoveryParam: 0,
     v: txObj.v
   };
   const signature = ethers.utils.joinSignature(expandedSig);

--- a/ethers-ext/example/signRecover/1_tx_signRecover_legacy.js
+++ b/ethers-ext/example/signRecover/1_tx_signRecover_legacy.js
@@ -3,35 +3,42 @@ const ethers = require("ethers");
 // const { Wallet, parseKlay } = require("@klaytn/ethers-ext");
 const { Wallet, parseKlay } = require("../../dist/src");
 
-const recieverAddr = "0xc40b6909eb7085590e1c26cb3becc25368e249e9";
-// const senderAddr = "0xa2a8854b1802d8cd5de631e690817c253d6a9153";
-const senderAddr = "0x3208ca99480f82bfe240ca6bc06110cd12bb6366";
-// const senderPriv = "0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8";
-const senderPriv = "0xb3cf575dea0081563fe5482de2fe4425e025502b1f4ae7e02b2540ac0a5beda1";
+const senderPriv = "0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8";
 
 async function main() {
   const provider = new ethers.providers.JsonRpcProvider("https://public-en-baobab.klaytn.net");
-  //   const provider = new ethers.providers.JsonRpcProvider("http://localhost:8551");
   const wallet = new Wallet(senderPriv, provider);
+
+  const recieverAddr = wallet.address;
+  const senderAddr = wallet.address;
 
   let tx = {
     from: senderAddr,
     to: recieverAddr,
-    value: 1e12,
+    value: parseKlay("1"),
   };
 
-  tx = await wallet.populateTransaction(tx);
-  const senderTxHashRLP = await wallet.signTransaction(tx);
-  console.log(senderTxHashRLP);
+  // sign
+  const popedTx = await wallet.populateTransaction(tx);
+  const txHashRLP = await wallet.signTransaction(popedTx);
+  let txObj = ethers.utils.parseTransaction(txHashRLP);
+  console.log(txHashRLP);
+  console.log(txObj);
 
-  console.log(wallet.decodeTxFromRLP(senderTxHashRLP));
+  // verify
+  const rawTx = ethers.utils.serializeTransaction(popedTx);
+  const msgHash = ethers.utils.keccak256(rawTx);
+  const msgBytes = ethers.utils.arrayify(msgHash);
 
-  //   const test = await provider.send("klay_blockNumber", []);
-  //   console.log("test:", test);
+  const expandedSig = {
+    r: txObj.r,
+    s: txObj.s,
+    recoveryParam: 0, // not really sure what this does
+    v: txObj.v
+  };
+  const signature = ethers.utils.joinSignature(expandedSig);
 
-  //   const recoverAddr = await provider.send("klay_recoverFromTransaction", ["0x08f88608850ba43b7400827b0c94c40b6909eb7085590e1c26cb3becc25368e249e9880de0b6b3a764000094e15cd70a41dfb05e7214004d7d054801b2a2f06bf847f845820fe9a090421871e8fd77e08b6a72760006a15184a96cfc39c7486ea948d11fd830ae8aa05876248aa8dc0783d782e584e6f8d9bf977c698210a0eab3e754192d0954de65", "latest"]);
-  //   console.log("\nrecovered", recoverAddr);
-  const recoverAddr = await provider.send("klay_recoverFromTransaction", [senderTxHashRLP, "latest"]);
+  const recoverAddr = ethers.utils.recoverAddress(msgBytes, signature);
   console.log("\nsender", senderAddr, "\nrecovered", recoverAddr);
 }
 

--- a/ethers-ext/example/signRecover/1_tx_signRecover_legacy.js
+++ b/ethers-ext/example/signRecover/1_tx_signRecover_legacy.js
@@ -1,0 +1,38 @@
+const ethers = require("ethers");
+
+// const { Wallet, parseKlay } = require("@klaytn/ethers-ext");
+const { Wallet, parseKlay } = require("../../dist/src");
+
+const recieverAddr = "0xc40b6909eb7085590e1c26cb3becc25368e249e9";
+// const senderAddr = "0xa2a8854b1802d8cd5de631e690817c253d6a9153";
+const senderAddr = "0x3208ca99480f82bfe240ca6bc06110cd12bb6366";
+// const senderPriv = "0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8";
+const senderPriv = "0xb3cf575dea0081563fe5482de2fe4425e025502b1f4ae7e02b2540ac0a5beda1";
+
+async function main() {
+  const provider = new ethers.providers.JsonRpcProvider("https://public-en-baobab.klaytn.net");
+  //   const provider = new ethers.providers.JsonRpcProvider("http://localhost:8551");
+  const wallet = new Wallet(senderPriv, provider);
+
+  let tx = {
+    from: senderAddr,
+    to: recieverAddr,
+    value: 1e12,
+  };
+
+  tx = await wallet.populateTransaction(tx);
+  const senderTxHashRLP = await wallet.signTransaction(tx);
+  console.log(senderTxHashRLP);
+
+  console.log(wallet.decodeTxFromRLP(senderTxHashRLP));
+
+  //   const test = await provider.send("klay_blockNumber", []);
+  //   console.log("test:", test);
+
+  //   const recoverAddr = await provider.send("klay_recoverFromTransaction", ["0x08f88608850ba43b7400827b0c94c40b6909eb7085590e1c26cb3becc25368e249e9880de0b6b3a764000094e15cd70a41dfb05e7214004d7d054801b2a2f06bf847f845820fe9a090421871e8fd77e08b6a72760006a15184a96cfc39c7486ea948d11fd830ae8aa05876248aa8dc0783d782e584e6f8d9bf977c698210a0eab3e754192d0954de65", "latest"]);
+  //   console.log("\nrecovered", recoverAddr);
+  const recoverAddr = await provider.send("klay_recoverFromTransaction", [senderTxHashRLP, "latest"]);
+  console.log("\nsender", senderAddr, "\nrecovered", recoverAddr);
+}
+
+main();

--- a/ethers-ext/example/signRecover/2_tx_signRecover_pubkey.js
+++ b/ethers-ext/example/signRecover/2_tx_signRecover_pubkey.js
@@ -3,7 +3,7 @@ const ethers = require("ethers");
 // const { Wallet, parseKlay } = require("@klaytn/ethers-ext");
 const { Wallet, parseKlay, TxType } = require("../../dist/src");
 
-const recieverAddr = "0xe15cd70a41dfb05e7214004d7d054801b2a2f06b";
+const receiverAddr = "0xe15cd70a41dfb05e7214004d7d054801b2a2f06b";
 const senderAddr = "0xe15cd70a41dfb05e7214004d7d054801b2a2f06b";
 const senderPriv = "0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8";
 
@@ -14,7 +14,7 @@ async function main() {
   let tx = {
     type: TxType.ValueTransfer,
     from: senderAddr,
-    to: recieverAddr,
+    to: receiverAddr,
     value: parseKlay("1"),
   };
 

--- a/ethers-ext/example/signRecover/2_tx_signRecover_pubkey.js
+++ b/ethers-ext/example/signRecover/2_tx_signRecover_pubkey.js
@@ -1,0 +1,31 @@
+const ethers = require("ethers");
+
+// const { Wallet, parseKlay } = require("@klaytn/ethers-ext");
+const { Wallet, parseKlay, TxType } = require("../../dist/src");
+
+const recieverAddr = "0xe15cd70a41dfb05e7214004d7d054801b2a2f06b";
+const senderAddr = "0xe15cd70a41dfb05e7214004d7d054801b2a2f06b";
+const senderPriv = "0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8";
+
+async function main() {
+  const provider = new ethers.providers.JsonRpcProvider("https://public-en-baobab.klaytn.net");
+  const wallet = new Wallet(senderAddr, senderPriv, provider);
+
+  let tx = {
+    type: TxType.ValueTransfer,
+    from: senderAddr,
+    to: recieverAddr,
+    value: parseKlay("1"),
+  };
+
+  tx = await wallet.populateTransaction(tx);
+  const senderTxHashRLP = await wallet.signTransaction(tx);
+
+  console.log(senderTxHashRLP);
+  console.log(wallet.decodeTxFromRLP(senderTxHashRLP));
+
+  const recoverAddr = await provider.send("klay_recoverFromTransaction", [senderTxHashRLP, "latest"]);
+  console.log("\nsender", senderAddr, "\nrecovered", recoverAddr);
+}
+
+main();

--- a/ethers-ext/example/signRecover/3_tx_signRecover_multisig.js
+++ b/ethers-ext/example/signRecover/3_tx_signRecover_multisig.js
@@ -1,0 +1,52 @@
+const ethers = require("ethers");
+
+// const { Wallet, parseKlay } = require("@klaytn/ethers-ext");
+const { Wallet, parseKlay, TxType } = require("../../dist/src");
+
+
+const recieverAddr = "0x82c6a8d94993d49cfd0c1d30f0f8caa65782cc7e";
+const senderAddr = "0x82c6a8d94993d49cfd0c1d30f0f8caa65782cc7e";
+
+async function main() {
+  const provider = new ethers.providers.JsonRpcProvider("https://public-en-baobab.klaytn.net");
+
+  let user1 = new Wallet(
+    "0x82c6a8d94993d49cfd0c1d30f0f8caa65782cc7e",
+    "0xa32c30608667d43be2d652bede413f12a649dd1be93440878e7f712d51a6768a",
+    provider
+  );
+  let user2 = new Wallet(
+    "0x82c6a8d94993d49cfd0c1d30f0f8caa65782cc7e",
+    "0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8",
+    provider
+  );
+  let user3 = new Wallet(
+    "0x82c6a8d94993d49cfd0c1d30f0f8caa65782cc7e",
+    "0xc9668ccd35fc20587aa37a48838b48ccc13cf14dd74c8999dd6a480212d5f7ac",
+    provider
+  );
+
+  let tx = {
+    type: TxType.ValueTransfer,
+    from: senderAddr,
+    to: recieverAddr,
+    value: parseKlay("1"),
+  };
+
+  tx = await user1.populateTransaction(tx);
+  const senderTxHashRLP = await user1.signTransaction(tx);
+
+  const tx2 = await user2.populateTransaction(user2.decodeTxFromRLP(senderTxHashRLP));
+  const senderTxHashRLP2 = await user2.signTransaction(tx2);
+
+  const tx3 = await user3.populateTransaction(user3.decodeTxFromRLP(senderTxHashRLP2));
+  const senderTxHashRLP3 = await user3.signTransaction(tx3);
+
+  console.log(senderTxHashRLP3);
+  console.log(user1.decodeTxFromRLP(senderTxHashRLP3));
+
+  const recoverAddr = await provider.send("klay_recoverFromTransaction", [senderTxHashRLP3, "latest"]);
+  console.log("\nsender", senderAddr, "\nrecovered", recoverAddr);
+}
+
+main();

--- a/ethers-ext/example/signRecover/3_tx_signRecover_multisig.js
+++ b/ethers-ext/example/signRecover/3_tx_signRecover_multisig.js
@@ -4,7 +4,7 @@ const ethers = require("ethers");
 const { Wallet, parseKlay, TxType } = require("../../dist/src");
 
 
-const recieverAddr = "0x82c6a8d94993d49cfd0c1d30f0f8caa65782cc7e";
+const receiverAddr = "0x82c6a8d94993d49cfd0c1d30f0f8caa65782cc7e";
 const senderAddr = "0x82c6a8d94993d49cfd0c1d30f0f8caa65782cc7e";
 
 async function main() {
@@ -29,7 +29,7 @@ async function main() {
   let tx = {
     type: TxType.ValueTransfer,
     from: senderAddr,
-    to: recieverAddr,
+    to: receiverAddr,
     value: parseKlay("1"),
   };
 

--- a/ethers-ext/example/signRecover/4_tx_signRecover_rolebased.js
+++ b/ethers-ext/example/signRecover/4_tx_signRecover_rolebased.js
@@ -1,0 +1,37 @@
+const ethers = require("ethers");
+
+// const { Wallet, parseKlay } = require("@klaytn/ethers-ext");
+const { Wallet, parseKlay, TxType } = require("../../dist/src");
+
+
+const recieverAddr = "0x5bd2fb3c21564c023a4a735935a2b7a238c4ccea";
+const senderAddr = "0x5bd2fb3c21564c023a4a735935a2b7a238c4ccea";
+
+
+async function main() {
+  const provider = new ethers.providers.JsonRpcProvider("https://public-en-baobab.klaytn.net");
+
+  let user = new Wallet(
+    "0x5bd2fb3c21564c023a4a735935a2b7a238c4ccea",
+    "0xc9668ccd35fc20587aa37a48838b48ccc13cf14dd74c8999dd6a480212d5f7ac",
+    provider
+  );
+
+  let tx = {
+    type: TxType.ValueTransfer,
+    from: senderAddr,
+    to: recieverAddr,
+    value: parseKlay("1"),
+  };
+
+  tx = await user.populateTransaction(tx);
+  const senderTxHashRLP = await user.signTransaction(tx);
+
+  console.log(senderTxHashRLP);
+  console.log(user.decodeTxFromRLP(senderTxHashRLP));
+
+  const recoverAddr = await provider.send("klay_recoverFromTransaction", [senderTxHashRLP, "latest"]);
+  console.log("\nsender", senderAddr, "\nrecovered", recoverAddr);
+}
+
+main();

--- a/ethers-ext/example/signRecover/4_tx_signRecover_rolebased.js
+++ b/ethers-ext/example/signRecover/4_tx_signRecover_rolebased.js
@@ -4,7 +4,7 @@ const ethers = require("ethers");
 const { Wallet, parseKlay, TxType } = require("../../dist/src");
 
 
-const recieverAddr = "0x5bd2fb3c21564c023a4a735935a2b7a238c4ccea";
+const receiverAddr = "0x5bd2fb3c21564c023a4a735935a2b7a238c4ccea";
 const senderAddr = "0x5bd2fb3c21564c023a4a735935a2b7a238c4ccea";
 
 
@@ -20,7 +20,7 @@ async function main() {
   let tx = {
     type: TxType.ValueTransfer,
     from: senderAddr,
-    to: recieverAddr,
+    to: receiverAddr,
     value: parseKlay("1"),
   };
 

--- a/ethers-ext/example/signRecover/5_msg_signRecover_legacy.js
+++ b/ethers-ext/example/signRecover/5_msg_signRecover_legacy.js
@@ -1,0 +1,20 @@
+const ethers = require("ethers");
+
+// const { Wallet, parseKlay } = require("@klaytn/ethers-ext");
+const { Wallet} = require("../../dist/src");
+
+async function main() {
+  const provider = new ethers.providers.JsonRpcProvider("https://public-en-baobab.klaytn.net");
+  const wallet = new Wallet("0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8", provider);
+
+  const address = wallet.address;
+  let msg = "I♥KLAYTN";
+  let msgHash = ethers.utils.hashMessage(msg);
+  let msgHashBytes = ethers.utils.arrayify(msgHash);
+  const signature = await wallet.signMessage(msgHashBytes);
+
+  const recoverAddr = await provider.send("klay_recoverFromMessage", [address, msgHash, signature, "latest"]);
+  console.log("\nsender", address, "\nrecovered", recoverAddr);
+}
+
+main();

--- a/ethers-ext/example/signRecover/6_msg_signRecover_pubkey.js
+++ b/ethers-ext/example/signRecover/6_msg_signRecover_pubkey.js
@@ -1,0 +1,23 @@
+const ethers = require("ethers");
+
+// const { Wallet, parseKlay } = require("@klaytn/ethers-ext");
+const { Wallet} = require("../../dist/src");
+
+async function main() {
+  const provider = new ethers.providers.JsonRpcProvider("https://public-en-baobab.klaytn.net");
+  const wallet = new Wallet(
+    "0xe15cd70a41dfb05e7214004d7d054801b2a2f06b",
+    "0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8",
+    provider);
+
+  const address = wallet.address;
+  let msg = "I♥KLAYTN";
+  let msgHash = ethers.utils.hashMessage(msg);
+  let msgHashBytes = ethers.utils.arrayify(msgHash);
+  const signature = await wallet.signMessage(msgHashBytes);
+
+  const recoverAddr = await provider.send("klay_recoverFromMessage", [address, msgHash, signature, "latest"]);
+  console.log("\nsender", address, "\nrecovered", recoverAddr);
+}
+
+main();

--- a/ethers-ext/example/signRecover/7_msg_signRecover_multisig.js
+++ b/ethers-ext/example/signRecover/7_msg_signRecover_multisig.js
@@ -1,0 +1,25 @@
+const ethers = require("ethers");
+
+// const { Wallet, parseKlay } = require("@klaytn/ethers-ext");
+const { Wallet} = require("../../dist/src");
+
+async function main() {
+  const provider = new ethers.providers.JsonRpcProvider("https://public-en-baobab.klaytn.net");
+  const wallet = new Wallet(
+    // multisig account address
+    "0x82c6a8d94993d49cfd0c1d30f0f8caa65782cc7e",
+    // a member key of multisig account
+    "0xc9668ccd35fc20587aa37a48838b48ccc13cf14dd74c8999dd6a480212d5f7ac",
+    provider);
+
+  const address = wallet.address;
+  let msg = "I♥KLAYTN";
+  let msgHash = ethers.utils.hashMessage(msg);
+  let msgHashBytes = ethers.utils.arrayify(msgHash);
+  const signature = await wallet.signMessage(msgHashBytes);
+
+  const recoverAddr = await provider.send("klay_recoverFromMessage", [address, msgHash, signature, "latest"]);
+  console.log("\nsender", address, "\nrecovered", recoverAddr);
+}
+
+main();

--- a/ethers-ext/example/signRecover/7_msg_signRecover_multisig.js
+++ b/ethers-ext/example/signRecover/7_msg_signRecover_multisig.js
@@ -3,16 +3,15 @@ const ethers = require("ethers");
 // const { Wallet, parseKlay } = require("@klaytn/ethers-ext");
 const { Wallet} = require("../../dist/src");
 
+// multisig account address
+const address = "0x82c6a8d94993d49cfd0c1d30f0f8caa65782cc7e";
+// a member private key of multisig account
+const priv = "0xc9668ccd35fc20587aa37a48838b48ccc13cf14dd74c8999dd6a480212d5f7ac";
+
 async function main() {
   const provider = new ethers.providers.JsonRpcProvider("https://public-en-baobab.klaytn.net");
-  const wallet = new Wallet(
-    // multisig account address
-    "0x82c6a8d94993d49cfd0c1d30f0f8caa65782cc7e",
-    // a member key of multisig account
-    "0xc9668ccd35fc20587aa37a48838b48ccc13cf14dd74c8999dd6a480212d5f7ac",
-    provider);
+  const wallet = new Wallet(address, priv, provider);
 
-  const address = wallet.address;
   let msg = "I♥KLAYTN";
   let msgHash = ethers.utils.hashMessage(msg);
   let msgHashBytes = ethers.utils.arrayify(msgHash);
@@ -20,6 +19,7 @@ async function main() {
 
   const recoverAddr = await provider.send("klay_recoverFromMessage", [address, msgHash, signature, "latest"]);
   console.log("\nsender", address, "\nrecovered", recoverAddr);
+  console.log("private key's legacy type address", await wallet.getEtherAddress());
 }
 
 main();

--- a/ethers-ext/example/signRecover/8_msg_signRecover_rolebased.js
+++ b/ethers-ext/example/signRecover/8_msg_signRecover_rolebased.js
@@ -1,0 +1,30 @@
+const ethers = require("ethers");
+
+// const { Wallet, parseKlay } = require("@klaytn/ethers-ext");
+const { Wallet} = require("../../dist/src");
+
+async function main() {
+  const provider = new ethers.providers.JsonRpcProvider("https://public-en-baobab.klaytn.net");
+  const wallet = new Wallet(
+    // role-based account address
+    "0x5bd2fb3c21564c023a4a735935a2b7a238c4ccea",
+    // transaction role key of role-based account
+    "0xc9668ccd35fc20587aa37a48838b48ccc13cf14dd74c8999dd6a480212d5f7ac",
+    provider);
+
+
+  const address = wallet.address;
+  let msg = "I♥KLAYTN";
+  let msgHash = ethers.utils.hashMessage(msg);
+  let msgHashBytes = ethers.utils.arrayify(msgHash);
+  const signature = await wallet.signMessage(msgHashBytes);
+
+  //   const address = "0xA2a8854b1802D8Cd5De631E690817c253d6a9153";
+  //   const message = "0xdeadbeef";
+  //   const signature = "0x1e6338d6e4a8d688a25de78cf2a92efec9a92e52eb8425acaaee8c3957e68cdb3f91bdc483f0ed05a0da26eca3be4c566d087d90dc2ca293be23b2a9de0bcafc1c";
+
+  const recoverAddr = await provider.send("klay_recoverFromMessage", [address, msgHash, signature, "latest"]);
+  console.log("\nsender", address, "\nrecovered", recoverAddr);
+}
+
+main();

--- a/ethers-ext/example/signRecover/8_msg_signRecover_rolebased.js
+++ b/ethers-ext/example/signRecover/8_msg_signRecover_rolebased.js
@@ -3,28 +3,23 @@ const ethers = require("ethers");
 // const { Wallet, parseKlay } = require("@klaytn/ethers-ext");
 const { Wallet} = require("../../dist/src");
 
+// role-based account address
+const address = "0x5bd2fb3c21564c023a4a735935a2b7a238c4ccea";
+// transaction role key of role-based account
+const priv = "0xc9668ccd35fc20587aa37a48838b48ccc13cf14dd74c8999dd6a480212d5f7ac";
+
 async function main() {
   const provider = new ethers.providers.JsonRpcProvider("https://public-en-baobab.klaytn.net");
-  const wallet = new Wallet(
-    // role-based account address
-    "0x5bd2fb3c21564c023a4a735935a2b7a238c4ccea",
-    // transaction role key of role-based account
-    "0xc9668ccd35fc20587aa37a48838b48ccc13cf14dd74c8999dd6a480212d5f7ac",
-    provider);
+  const wallet = new Wallet(address, priv, provider);
 
-
-  const address = wallet.address;
   let msg = "I♥KLAYTN";
   let msgHash = ethers.utils.hashMessage(msg);
   let msgHashBytes = ethers.utils.arrayify(msgHash);
   const signature = await wallet.signMessage(msgHashBytes);
 
-  //   const address = "0xA2a8854b1802D8Cd5De631E690817c253d6a9153";
-  //   const message = "0xdeadbeef";
-  //   const signature = "0x1e6338d6e4a8d688a25de78cf2a92efec9a92e52eb8425acaaee8c3957e68cdb3f91bdc483f0ed05a0da26eca3be4c566d087d90dc2ca293be23b2a9de0bcafc1c";
-
   const recoverAddr = await provider.send("klay_recoverFromMessage", [address, msgHash, signature, "latest"]);
   console.log("\nsender", address, "\nrecovered", recoverAddr);
+  console.log("private key's legacy type address", await wallet.getEtherAddress());
 }
 
 main();


### PR DESCRIPTION
- signRecover for transaction (legacy, pubkey, multisig, rolebased) 
- signRecover for message (legacy, pubkey, multisig, rolebased) 
