### PR TITLE
version up to v0.9.4

### DIFF
--- a/ethers-ext/package.json
+++ b/ethers-ext/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klaytn/ethers-ext",
-  "version": "0.9.3-beta",
+  "version": "0.9.4-beta",
   "main": "dist/src/index.js",
   "files": [
     "./dist",

--- a/web3j-ext/web3j-ext/build.gradle
+++ b/web3j-ext/web3j-ext/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'foundation.klaytn'
-version 'v0.9.3'
+version 'v0.9.4'
 
 repositories {
     mavenCentral()
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    implementation "foundation.klaytn:web3rpc-java:v0.9.0"
+    implementation "foundation.klaytn:web3rpc-java:v0.9.3"
     implementation "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.30.0"
     implementation "org.web3j:core:4.9.8"
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.14.2'

--- a/web3py-ext/setup.py
+++ b/web3py-ext/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 NAME = "web3py_ext"
-VERSION = "0.9.3-beta"
+VERSION = "0.9.4-beta"
 # To install the library, run the following
 #
 # python setup.py install

--- a/web3rpc/sdk/client/java/java-config.yaml
+++ b/web3rpc/sdk/client/java/java-config.yaml
@@ -3,7 +3,7 @@ outputDir: ./openapi/
 inputSpec: ../../../rpc-specs/namespaces/all-except-eth.yaml 
 groupId: foundation.klaytn
 artifactId: web3rpc-java
-artifactVersion: v0.9.3
+artifactVersion: v0.9.4
 library: retrofit2
 templateDir: ./template
 globalProperties:

--- a/web3rpc/sdk/client/javascript/javascript-config.yaml
+++ b/web3rpc/sdk/client/javascript/javascript-config.yaml
@@ -2,6 +2,7 @@ generatorName: web3rpc-javascript
 outputDir: ./openapi
 inputSpec: ../../../rpc-specs/namespaces/all-except-eth.yaml
 projectName: "@klaytn/web3rpc"
+projectVersion: "0.9.4"
 templateDir: ./template
 sortParamsByRequiredFlag: false
 globalProperties:


### PR DESCRIPTION
- web3rpc-javascript (as is 0.9.0 --> to be 0.9.4)
  - to sync with other packages
- web3rpc-java (as is 0.9.3 --> to be 0.9.4)
- ethers-ext (as is 0.9.3-beta --> to be 0.9.4-beta)
  - It is currently using the web3rpc-javascript-v0.9.0 and will has no any changes (will be changed in next release)
- web3j-ext (as is 0.9.3 --> to be 0.9.4)
  - It is currently using the web3rpc-java-v0.9.0 and will be updated to use v0.9.3 (can’t use v0.9.4 because deploy delay)
- web3py-ext (as is 0.9.3-beta --> to be 0.9.4-beta)