### PR TITLE
Overriding web3.eth.accounts

### DIFF
--- a/web3js-ext/example/create.js
+++ b/web3js-ext/example/create.js
@@ -1,0 +1,13 @@
+const { Web3 } = require("web3");
+const { KlaytnWeb3 } = require( "../dist/src");
+
+
+async function main() {
+  let provider = new Web3.providers.HttpProvider("https://public-en-baobab.klaytn.net");
+  let web3 = new KlaytnWeb3(provider);
+
+  let result = await web3.eth.accounts.create();
+  console.log({ result });
+}
+
+main().catch(console.err);

--- a/web3js-ext/example/privateKeyToAccount.js
+++ b/web3js-ext/example/privateKeyToAccount.js
@@ -1,0 +1,34 @@
+const { Web3 } = require("web3");
+const { KlaytnWeb3 } = require( "../dist/src");
+const { TxType, parseKlay } = require("@klaytn/ethers-ext");
+
+
+const recieverAddr = "0xc40b6909eb7085590e1c26cb3becc25368e249e9";
+const senderAddr = "0xa2a8854b1802d8cd5de631e690817c253d6a9153";
+const senderPriv = "0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8";
+
+async function main() {
+  let provider = new Web3.providers.HttpProvider("https://public-en-baobab.klaytn.net");
+  let web3 = new KlaytnWeb3(provider);
+
+  let signResult = await web3.eth.accounts.privateKeyToAccount(senderPriv).signTransaction(    
+    {
+      type: TxType.ValueTransfer,
+      to: recieverAddr,
+      value: 1e9,
+      // value: convertToPeb('1', 'KLAY'),
+      from: senderAddr,
+      gas: 21000,
+      gasPrice: 25e9,
+    }
+  ); 
+  console.log({ signResult });
+
+  let sendResult = await web3.eth.sendSignedTransaction(signResult.rawTransaction);
+  let txhash = sendResult.transactionHash;
+
+  let receipt = await web3.eth.getTransactionReceipt(txhash);
+  console.log({ receipt });
+}
+
+main().catch(console.err);

--- a/web3js-ext/example/recoverTransaction.js
+++ b/web3js-ext/example/recoverTransaction.js
@@ -1,0 +1,44 @@
+const { Web3 } = require("web3");
+const { KlaytnWeb3 } = require( "../dist/src");
+
+const { TxType, parseKlay } = require("@klaytn/ethers-ext");
+
+
+const senderPriv = "0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8";
+
+
+async function main() {
+  let provider = new Web3.providers.HttpProvider("https://public-en-baobab.klaytn.net");
+  let web3 = new KlaytnWeb3(provider);
+
+  // ethereum's rawTransaction 
+  const rawTransaction = '0xf869808504e3b29200831e848094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca008025a0c9cf86333bcb065d140032ecaab5d9281bde80f21b9687b3e94161de42d51895a0727a108a0b8d101465414033c3f705a9c7b826e596766046ee1183dbc8aeaa68';
+  let address = await web3.eth.accounts.recoverTransaction(rawTransaction);
+  console.log("\nsender", "0x2c7536E3605D9C16a7a3D7b1898e529396a65c23");
+  console.log("\nrecovered", address);
+
+  // Klaytn's rawTransaction 
+  const account = await web3.eth.accounts.privateKeyToAccount(senderPriv); 
+  const receiverAddr = account.address;
+  const senderAddr = account.address;
+
+  let tx = {
+    type: TxType.ValueTransfer,
+    to: receiverAddr,
+    value: 1e9,
+    // value: convertToPeb('1', 'KLAY'),
+    from: senderAddr,
+    gas: 21000,
+    gasPrice: 25e9,
+  };
+
+  let signResult = await web3.eth.accounts.signTransaction(tx, account.privateKey);
+  console.log({ signResult });
+
+  address = await web3.eth.accounts.recoverTransaction(signResult.rawTransaction);
+  console.log("\nsender", senderAddr);
+  console.log("\nrecovered", address);
+
+}
+
+main().catch(console.err);

--- a/web3js-ext/example/recoverTransaction.js
+++ b/web3js-ext/example/recoverTransaction.js
@@ -1,44 +1,21 @@
 const { Web3 } = require("web3");
 const { KlaytnWeb3 } = require( "../dist/src");
 
-const { TxType, parseKlay } = require("@klaytn/ethers-ext");
-
-
-const senderPriv = "0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8";
-
-
 async function main() {
   let provider = new Web3.providers.HttpProvider("https://public-en-baobab.klaytn.net");
   let web3 = new KlaytnWeb3(provider);
 
   // ethereum's rawTransaction 
-  const rawTransaction = '0xf869808504e3b29200831e848094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca008025a0c9cf86333bcb065d140032ecaab5d9281bde80f21b9687b3e94161de42d51895a0727a108a0b8d101465414033c3f705a9c7b826e596766046ee1183dbc8aeaa68';
+  let rawTransaction = '0xf869808504e3b29200831e848094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca008025a0c9cf86333bcb065d140032ecaab5d9281bde80f21b9687b3e94161de42d51895a0727a108a0b8d101465414033c3f705a9c7b826e596766046ee1183dbc8aeaa68';
   let address = await web3.eth.accounts.recoverTransaction(rawTransaction);
   console.log("\nsender", "0x2c7536E3605D9C16a7a3D7b1898e529396a65c23");
-  console.log("\nrecovered", address);
+  console.log("recovered", address);
 
   // Klaytn's rawTransaction 
-  const account = await web3.eth.accounts.privateKeyToAccount(senderPriv); 
-  const receiverAddr = account.address;
-  const senderAddr = account.address;
-
-  let tx = {
-    type: TxType.ValueTransfer,
-    to: receiverAddr,
-    value: 1e9,
-    // value: convertToPeb('1', 'KLAY'),
-    from: senderAddr,
-    gas: 21000,
-    gasPrice: 25e9,
-  };
-
-  let signResult = await web3.eth.accounts.signTransaction(tx, account.privateKey);
-  console.log({ signResult });
-
-  address = await web3.eth.accounts.recoverTransaction(signResult.rawTransaction);
-  console.log("\nsender", senderAddr);
-  console.log("\nrecovered", address);
-
+  rawTransaction = '0x08f88482020b8505d21dba0082520894a2a8854b1802d8cd5de631e690817c253d6a9153843b9aca0094a2a8854b1802d8cd5de631e690817c253d6a9153f847f8458207f6a00739be424c6074a17b38badc0a10ca30e50a3b56dce73ecf60cec1dbb48ebde5a0039d8ce12722feb26fe784932e2b4100982232d81efd1960dc846d6c6c49efdb';
+  address = await web3.eth.accounts.recoverTransaction(rawTransaction);
+  console.log("\nsender", "0xA2a8854b1802D8Cd5De631E690817c253d6a9153");
+  console.log("recovered", address);
 }
 
 main().catch(console.err);

--- a/web3js-ext/example/wallet.js
+++ b/web3js-ext/example/wallet.js
@@ -1,0 +1,24 @@
+const { Web3 } = require("web3");
+const { KlaytnWeb3 } = require( "../dist/src");
+
+const senderAddr = "0xa2a8854b1802d8cd5de631e690817c253d6a9153";
+const senderPriv = "0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8";
+
+async function main() {
+  let provider = new Web3.providers.HttpProvider("https://public-en-baobab.klaytn.net");
+  let web3 = new KlaytnWeb3(provider);
+
+  let wallet = await web3.eth.accounts.wallet.create(2); 
+  console.log(wallet);
+
+  wallet = await web3.eth.accounts.wallet.add(senderPriv);
+  console.log(wallet); 
+
+  wallet = await web3.eth.accounts.wallet.remove(senderAddr);
+  console.log(web3.eth.accounts.wallet); 
+
+  wallet = await web3.eth.accounts.wallet.clear();
+  console.log(wallet); 
+}
+
+main().catch(console.err);

--- a/web3js-ext/src/web3/account.ts
+++ b/web3js-ext/src/web3/account.ts
@@ -108,22 +108,22 @@ export const signTransactionAsFeePayer = async (
  * 	}
  * ```
  */
-export const privateKeyToAccountWithContext = (context: Web3Context, privateKey: Bytes, ignoreLength?: boolean): Web3Account => {
-  // web3/src/accounts.ts:initAccountsForContext
-  const account = privateKeyToAccount(privateKey);
+// export const privateKeyToAccountWithContext = (context: Web3Context, privateKey: Bytes, ignoreLength?: boolean): Web3Account => {
+//   // web3/src/accounts.ts:initAccountsForContext
+//   const account = privateKeyToAccount(privateKey);
 
-  return {
-    ...account,
-    signTransaction: async (transaction: Transaction) =>
-      signTransactionWithContext(transaction, account.privateKey),
-  };
-};
+//   return {
+//     ...account,
+//     signTransaction: async (transaction: Transaction) =>
+//       signTransactionWithContext(transaction, account.privateKey),
+//   };
+// };
 
-export const signTransactionWithContext = async(transaction: Transaction, context: Web3Context, privateKey: Bytes) {
-	let tx = await prepareTransaction(transaction, context, privateKey);
-	let priv = bytesToHex(privateKey);
-	return signTransaction(tx, priv);
-};
+// export const signTransactionWithContext = async(transaction: Transaction, context: Web3Context, privateKey: Bytes) {
+// 	let tx = await prepareTransaction(transaction, context, privateKey);
+// 	let priv = bytesToHex(privateKey);
+// 	return signTransaction(tx, priv);
+// };
 
 /**
  *

--- a/web3js-ext/src/web3/account.ts
+++ b/web3js-ext/src/web3/account.ts
@@ -1,7 +1,9 @@
+import Web3, {Web3Context} from "web3";
 import {
 	TransactionSigningError,
 } from 'web3-errors';
 import {
+	Bytes,
 	HexString,
 } from 'web3-types';
 import {
@@ -10,9 +12,20 @@ import {
 	sha3Raw,
 } from 'web3-utils';
 
-import { TypedTransaction, SignTransactionResult } from "web3-eth-accounts";
+import { 
+	Web3Account,
+	Transaction,
+	TypedTransaction, 
+	sign,
+	signTransaction,
+	SignTransactionResult, 
+	parseAndValidatePrivateKey,
+	privateKeyToAddress,
+	encrypt,
+} from "web3-eth-accounts";
 import { isNullish } from 'web3-validator';
 
+import { prepareTransaction } from "./klaytn_tx";
 
 export const signTransactionAsFeePayer = async (
 	transaction: TypedTransaction,
@@ -46,5 +59,47 @@ export const signTransactionAsFeePayer = async (
 		s: `0x${signedTx.feePayer_s.toString(16).padStart(64, '0')}`,
 		rawTransaction: rawTx,
 		transactionHash: bytesToHex(txHash),
+	};
+};
+
+/**
+ * Get an Account object from the privateKey
+ *
+ * @param privateKey - String or Uint8Array of 32 bytes
+ * @param ignoreLength - if true, will not error check length
+ * @returns A Web3Account object
+ *
+ * The `Web3Account.signTransaction` is not stateful here. We need network access to get the account `nonce` and `chainId` to sign the transaction.
+ * Use {@link Web3.eth.accounts.signTransaction} instead.
+ *
+ * ```ts
+ * privateKeyToAccount("0x348ce564d427a3311b6536bbcff9390d69395b06ed6c486954e971d960fe8709");
+ * >    {
+ * 			address: '0xb8CE9ab6943e0eCED004cDe8e3bBed6568B2Fa01',
+ * 			privateKey: '0x348ce564d427a3311b6536bbcff9390d69395b06ed6c486954e971d960fe8709',
+ * 			sign,
+ * 			signTransaction,
+ * 			encrypt,
+ * 	}
+ * ```
+ */
+export const privateKeyToAccount = (context: Web3Context, privateKey: Bytes, ignoreLength?: boolean): Web3Account => {
+	const privateKeyUint8Array = parseAndValidatePrivateKey(privateKey, ignoreLength);
+
+	return {
+		address: privateKeyToAddress(privateKeyUint8Array),
+		privateKey: bytesToHex(privateKeyUint8Array),
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		// @ts-ignore
+		signTransaction: async (otx: Transaction): Promise<SignTransactionResult> => {
+			// @ts-ignore
+			let tx = await prepareTransaction(otx, context, privateKey);
+			let priv = bytesToHex(privateKey);
+			return signTransaction(tx, priv);
+		},
+		sign: (data: Record<string, unknown> | string) =>
+			sign(typeof data === 'string' ? data : JSON.stringify(data), privateKeyUint8Array),
+		encrypt: async (password: string, options?: Record<string, unknown>) =>
+			encrypt(privateKeyUint8Array, password, options),
 	};
 };

--- a/web3js-ext/src/web3/account.ts
+++ b/web3js-ext/src/web3/account.ts
@@ -154,7 +154,7 @@ export const createWithContext = (context: Web3Context): Web3Account => {
  * > "0x2c7536E3605D9C16a7a3D7b1898e529396a65c23"
  * ```
  */
-export const recoverTransactionWithKlaytnTx = (context: Web3Context, rawTransaction: HexString): Address => {
+export const recoverTransactionWithKlaytnTx = (rawTransaction: HexString): Address => {
 	if (isNullish(rawTransaction)) throw new UndefinedRawTransactionError();
 
 	const data = hexToBytes(rawTransaction);

--- a/web3js-ext/src/web3/account.ts
+++ b/web3js-ext/src/web3/account.ts
@@ -88,44 +88,6 @@ export const signTransactionAsFeePayer = async (
 };
 
 /**
- * Get an Account object from the privateKey with context
- * 
- * @param context - web3 context
- * @param privateKey - String or Uint8Array of 32 bytes
- * @param ignoreLength - if true, will not error check length
- * @returns A Web3Account object
- *
- * ```ts
- * let provider = new Web3.providers.HttpProvider("https://public-en-baobab.klaytn.net");
- * let web3 = new KlaytnWeb3(provider);
- * web3.eth.accounts.privateKeyToAccount("0x348ce564d427a3311b6536bbcff9390d69395b06ed6c486954e971d960fe8709");
- * >    {
- * 			address: '0xb8CE9ab6943e0eCED004cDe8e3bBed6568B2Fa01',
- * 			privateKey: '0x348ce564d427a3311b6536bbcff9390d69395b06ed6c486954e971d960fe8709',
- * 			sign,
- * 			signTransaction,
- * 			encrypt,
- * 	}
- * ```
- */
-// export const privateKeyToAccountWithContext = (context: Web3Context, privateKey: Bytes, ignoreLength?: boolean): Web3Account => {
-//   // web3/src/accounts.ts:initAccountsForContext
-//   const account = privateKeyToAccount(privateKey);
-
-//   return {
-//     ...account,
-//     signTransaction: async (transaction: Transaction) =>
-//       signTransactionWithContext(transaction, account.privateKey),
-//   };
-// };
-
-// export const signTransactionWithContext = async(transaction: Transaction, context: Web3Context, privateKey: Bytes) {
-// 	let tx = await prepareTransaction(transaction, context, privateKey);
-// 	let priv = bytesToHex(privateKey);
-// 	return signTransaction(tx, priv);
-// };
-
-/**
  *
  * Generates and returns a Web3Account object that includes the private and public key
  * For creation of private key, it uses an audited package ethereum-cryptography/secp256k1
@@ -144,11 +106,11 @@ export const signTransactionAsFeePayer = async (
  * }
  * ```
  */
-export const createWithContext = (context: Web3Context): Web3Account => {
-	const privateKey = secp256k1.utils.randomPrivateKey();
+// export const createWithContext = (context: Web3Context): Web3Account => {
+// 	const privateKey = secp256k1.utils.randomPrivateKey();
 
-	return privateKeyToAccountWithContext(context, bytesToHex(privateKey));
-};
+// 	return privateKeyToAccountWithContext(context, bytesToHex(privateKey));
+// };
 
 /**
  * Recovers the Ethereum address which was used to sign the given RLP encoded transaction.

--- a/web3js-ext/src/web3/account.ts
+++ b/web3js-ext/src/web3/account.ts
@@ -6,16 +6,19 @@ import {
 import {
 	Bytes,
 	HexString,
+	Address,
 } from 'web3-types';
 import {
 	bytesToHex,
 	hexToBytes,
 	sha3Raw,
+	toChecksumAddress,
 } from 'web3-utils';
 
 import { 
 	Web3Account,
 	Transaction,
+	TransactionFactory,
 	TypedTransaction, 
 	sign,
 	signTransaction,
@@ -146,12 +149,10 @@ export const createWithContext = (context: Web3Context): Web3Account => {
  * > "0x2c7536E3605D9C16a7a3D7b1898e529396a65c23"
  * ```
  */
-export const recoverTransactionWithKlaytnTx = async (context: Web3Context, rawTransaction: HexString): Address => {
+export const recoverTransactionWithKlaytnTx = (context: Web3Context, rawTransaction: HexString): Address => {
 	if (isNullish(rawTransaction)) throw new UndefinedRawTransactionError();
 
 	const tx = TransactionFactory.fromSerializedData(hexToBytes(rawTransaction));
-
-	await... 
 
 	return toChecksumAddress(tx.getSenderAddress().toString());
 };

--- a/web3js-ext/src/web3/account.ts
+++ b/web3js-ext/src/web3/account.ts
@@ -87,30 +87,6 @@ export const signTransactionAsFeePayer = async (
 	};
 };
 
-/**
- *
- * Generates and returns a Web3Account object that includes the private and public key
- * For creation of private key, it uses an audited package ethereum-cryptography/secp256k1
- * that is cryptographically secure random number with certain characteristics.
- * Read more: https://www.npmjs.com/package/ethereum-cryptography#secp256k1-curve
- *
- * @returns A Web3Account object
- * ```ts
- * web3.eth.accounts.create();
- * {
- * address: '0xbD504f977021b5E5DdccD8741A368b147B3B38bB',
- * privateKey: '0x964ced1c69ad27a311c432fdc0d8211e987595f7eb34ab405a5f16bdc9563ec5',
- * signTransaction: [Function: signTransaction],
- * sign: [Function: sign],
- * encrypt: [AsyncFunction: encrypt]
- * }
- * ```
- */
-// export const createWithContext = (context: Web3Context): Web3Account => {
-// 	const privateKey = secp256k1.utils.randomPrivateKey();
-
-// 	return privateKeyToAccountWithContext(context, bytesToHex(privateKey));
-// };
 
 /**
  * Recovers the Ethereum address which was used to sign the given RLP encoded transaction.
@@ -144,7 +120,7 @@ export const recoverTransactionWithKlaytnTx = (rawTransaction: HexString): Addre
 	return toChecksumAddress(tx.getSenderAddress().toString());
 };
 
-
+// We overrided web3/src/accounts.ts:initAccountsForContext
 export const initAccountsForContext = (context: Web3Context<EthExecutionAPI>) => {
 	const signTransactionWithContext = async (transaction: Transaction, privateKey: Bytes) => {
 		const tx = await prepareTransactionForSigning(transaction, context);

--- a/web3js-ext/src/web3/account.ts
+++ b/web3js-ext/src/web3/account.ts
@@ -172,10 +172,11 @@ export const initAccountsForContext = (context: Web3Context<EthExecutionAPI>) =>
 
 	return {
 		signTransaction: signTransactionWithContext,
+		signTransactionAsFeePayer: signTransactionAsFeePayer, 
 		create: createWithContext,
 		privateKeyToAccount: privateKeyToAccountWithContext,
 		decrypt: decryptWithContext,
-		recoverTransaction,
+		recoverTransaction: recoverTransactionWithKlaytnTx,
 		hashMessage,
 		sign,
 		recover,

--- a/web3js-ext/src/web3/account.ts
+++ b/web3js-ext/src/web3/account.ts
@@ -99,24 +99,13 @@ export const signTransactionAsFeePayer = async (
  * ```
  */
 export const privateKeyToAccountWithContext = (context: Web3Context, privateKey: Bytes, ignoreLength?: boolean): Web3Account => {
-	const privateKeyUint8Array = parseAndValidatePrivateKey(privateKey, ignoreLength);
-
-	return {
-		address: privateKeyToAddress(privateKeyUint8Array),
-		privateKey: bytesToHex(privateKeyUint8Array),
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		// @ts-ignore
-		signTransaction: async (otx: Transaction): Promise<SignTransactionResult> => {
-			// @ts-ignore
-			let tx = await prepareTransaction(otx, context, privateKey);
-			let priv = bytesToHex(privateKey);
-			return signTransaction(tx, priv);
-		},
-		sign: (data: Record<string, unknown> | string) =>
-			sign(typeof data === 'string' ? data : JSON.stringify(data), privateKeyUint8Array),
-		encrypt: async (password: string, options?: Record<string, unknown>) =>
-			encrypt(privateKeyUint8Array, password, options),
-	};
+  // web3/src/accounts.ts:initAccountsForContext
+  const account = privateKeyToAccount(privateKey);
+  return {
+    ...account,
+    signTransaction: async (transaction: Transaction) =>
+      signTransactionWithContext(transaction, account.privateKey),
+  };
 };
 
 /**

--- a/web3js-ext/src/web3/account.ts
+++ b/web3js-ext/src/web3/account.ts
@@ -141,7 +141,7 @@ export const privateKeyToAccountWithContext = (context: Web3Context, privateKey:
 export const createWithContext = (context: Web3Context): Web3Account => {
 	const privateKey = secp256k1.utils.randomPrivateKey();
 
-	return privateKeyToAccountWithContext(context, `${bytesToHex(privateKey)}`);
+	return privateKeyToAccountWithContext(context, bytesToHex(privateKey));
 };
 
 /**

--- a/web3js-ext/src/web3/account.ts
+++ b/web3js-ext/src/web3/account.ts
@@ -1,6 +1,7 @@
 import Web3, {Web3Context} from "web3";
 import {
 	TransactionSigningError,
+	UndefinedRawTransactionError,
 } from 'web3-errors';
 import {
 	Bytes,
@@ -133,4 +134,24 @@ export const createWithContext = (context: Web3Context): Web3Account => {
 	const privateKey = secp256k1.utils.randomPrivateKey();
 
 	return privateKeyToAccountWithContext(context, `${bytesToHex(privateKey)}`);
+};
+
+/**
+ * Recovers the Ethereum address which was used to sign the given RLP encoded transaction.
+ *
+ * @param rawTransaction - The hex string having RLP encoded transaction
+ * @returns The Ethereum address used to sign this transaction
+ * ```ts
+ * recoverTransaction('0xf869808504e3b29200831e848094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca008025a0c9cf86333bcb065d140032ecaab5d9281bde80f21b9687b3e94161de42d51895a0727a108a0b8d101465414033c3f705a9c7b826e596766046ee1183dbc8aeaa68');
+ * > "0x2c7536E3605D9C16a7a3D7b1898e529396a65c23"
+ * ```
+ */
+export const recoverTransactionWithKlaytnTx = async (context: Web3Context, rawTransaction: HexString): Address => {
+	if (isNullish(rawTransaction)) throw new UndefinedRawTransactionError();
+
+	const tx = TransactionFactory.fromSerializedData(hexToBytes(rawTransaction));
+
+	await... 
+
+	return toChecksumAddress(tx.getSenderAddress().toString());
 };

--- a/web3js-ext/src/web3/account.ts
+++ b/web3js-ext/src/web3/account.ts
@@ -40,17 +40,10 @@ import {
 } from "web3-eth-accounts";
 import { isNullish } from 'web3-validator';
 
-import { prepareTransaction } from "./klaytn_tx";
-
 // TODO: Change the path after web3-core deployed
 const { objectFromRLP } = require("../../../../ethers-ext/dist/src");
 
 import { KlaytnTxFactory} from "@klaytn/ethers-ext";
-
-// eslint-disable-next-line import/extensions
-import * as ethereumCryptography from 'ethereum-cryptography/secp256k1.js';
-
-const secp256k1 = ethereumCryptography.secp256k1 ?? ethereumCryptography;
 
 export const signTransactionAsFeePayer = async (
 	transaction: TypedTransaction,
@@ -89,7 +82,7 @@ export const signTransactionAsFeePayer = async (
 
 
 /**
- * Recovers the Ethereum address which was used to sign the given RLP encoded transaction.
+ * Recovers the Ethereum address which was used to sign the given RLP encoded Ethereum & Klaytn transaction.
  *
  * @param rawTransaction - The hex string having RLP encoded transaction
  * @returns The Ethereum address used to sign this transaction
@@ -121,6 +114,7 @@ export const recoverTransactionWithKlaytnTx = (rawTransaction: HexString): Addre
 };
 
 // We overrided web3/src/accounts.ts:initAccountsForContext
+// Below methods are bound to the context 'web3'.
 export const initAccountsForContext = (context: Web3Context<EthExecutionAPI>) => {
 	const signTransactionWithContext = async (transaction: Transaction, privateKey: Bytes) => {
 		const tx = await prepareTransactionForSigning(transaction, context);
@@ -140,6 +134,7 @@ export const initAccountsForContext = (context: Web3Context<EthExecutionAPI>) =>
 		};
 	};
 
+	// TODO : we will support KeyStore V4. 
 	const decryptWithContext = async (
 		keystore: KeyStore | string,
 		password: string,

--- a/web3js-ext/src/web3/web3.ts
+++ b/web3js-ext/src/web3/web3.ts
@@ -8,10 +8,7 @@ import _ from "lodash";
 import { prepareTransaction } from "./klaytn_tx";
 import { klay_sendSignedTransaction } from "./send_transaction";
 import { 
-  privateKeyToAccountWithContext, 
   signTransactionAsFeePayer, 
-  createWithContext, 
-  recoverTransactionWithKlaytnTx,
   initAccountsForContext,
 } from "./account";
 
@@ -36,7 +33,6 @@ export class KlaytnWeb3 extends Web3 {
     // // The functions are bound to 'this' object.
     // // TODO: override more web3.eth.accounts methods
     // this.eth.accounts.create = this.accounts_create(this);
-    // this.eth.accounts.privateKeyToAccount = this.accounts_privateKeyToAccount(this);
     // this.eth.accounts.recoverTransaction = this.accounts_recoverTransaction();
     // this.eth.accounts.decrypt = this.accounts_decrypt;
 
@@ -67,12 +63,6 @@ export class KlaytnWeb3 extends Web3 {
   // accounts_create(context: Web3Context): typeof this.eth.accounts.create {
   //   return (): Web3Account => {
   //     return createWithContext(context);
-  //   }; 
-  // }
-
-  // accounts_privateKeyToAccount(context: Web3Context): typeof this.eth.accounts.privateKeyToAccount {
-  //   return (privateKey: Bytes, ignoreLength?: boolean): Web3Account => {
-  //     return privateKeyToAccountWithContext(context, privateKey, ignoreLength);
   //   }; 
   // }
 

--- a/web3js-ext/src/web3/web3.ts
+++ b/web3js-ext/src/web3/web3.ts
@@ -33,7 +33,7 @@ export class KlaytnWeb3 extends Web3 {
       create: this.eth.accounts.create, 
       privateKeyToAccount: this.eth.accounts.privateKeyToAccount,
       // @ts-ignore
-      decrypt: this.accounts_decrypt,
+      decrypt: this.eth.accounts.decrypt,
     });
 
     // New added function for Klaytn

--- a/web3js-ext/src/web3/web3.ts
+++ b/web3js-ext/src/web3/web3.ts
@@ -30,8 +30,6 @@ export class KlaytnWeb3 extends Web3 {
     this._accountProvider = accounts;
     this._wallet = accounts.wallet;
 
-    // this.eth.accounts.decrypt = this.accounts_decrypt;
-
     // this.eth.accounts.wallet = new Wallet({
     //   create: this.eth.accounts.create, 
     //   privateKeyToAccount: this.eth.accounts.privateKeyToAccount,
@@ -53,20 +51,6 @@ export class KlaytnWeb3 extends Web3 {
     // TODO: Connect web3.klay, web3.net, etc from @klaytn/web3rpc
 
   }
-
-  // Below methods return a function bound to the context 'web3'.
-
-
-  // async accounts_decrypt(keystore: KeyStore | string, password: string, options?: Record<string, unknown>){
-  //   const account = await decrypt(keystore, password, (options?.nonStrict as boolean) ?? true);
-
-  //   return {
-  //     ...account,
-  //   // TODO : decrypt function will be implemented with KeyStore V4 later
-  //   // signTransaction: async (transaction: Transaction) =>
-  //   // 	signTransactionWithContext(transaction, account.privateKey),
-  //   };
-  // }
 
   accounts_signTransactionAsFeePayer(context: Web3Context): typeof this.eth.accounts.signTransaction {
     return async (transaction: any, privateKey: Bytes): Promise<any> => {

--- a/web3js-ext/src/web3/web3.ts
+++ b/web3js-ext/src/web3/web3.ts
@@ -30,7 +30,6 @@ export class KlaytnWeb3 extends Web3 {
     this._accountProvider = accounts;
     this._wallet = accounts.wallet;
 
-    // this.eth.accounts.recoverTransaction = this.accounts_recoverTransaction();
     // this.eth.accounts.decrypt = this.accounts_decrypt;
 
     // this.eth.accounts.wallet = new Wallet({
@@ -66,12 +65,6 @@ export class KlaytnWeb3 extends Web3 {
   //   // TODO : decrypt function will be implemented with KeyStore V4 later
   //   // signTransaction: async (transaction: Transaction) =>
   //   // 	signTransactionWithContext(transaction, account.privateKey),
-  //   };
-  // }
-
-  // accounts_recoverTransaction(): typeof this.eth.accounts.recoverTransaction {
-  //   return (rawTransaction: HexString): Address => {
-  //     return recoverTransactionWithKlaytnTx(rawTransaction);
   //   };
   // }
 

--- a/web3js-ext/src/web3/web3.ts
+++ b/web3js-ext/src/web3/web3.ts
@@ -26,12 +26,13 @@ export class KlaytnWeb3 extends Web3 {
     this.eth.accounts.create = this.accounts_create(this);
     this.eth.accounts.privateKeyToAccount = this.accounts_privateKeyToAccount(this);
     this.eth.accounts.signTransaction = this.accounts_signTransaction(this);
-    this.eth.accounts.recoverTransaction = this.accounts_recoverTransaction(this);
+    this.eth.accounts.recoverTransaction = this.accounts_recoverTransaction();
     this.eth.accounts.decrypt = this.accounts_decrypt;
 
     this.eth.accounts.wallet = new Wallet({
       create: this.eth.accounts.create, 
       privateKeyToAccount: this.eth.accounts.privateKeyToAccount,
+      // @ts-ignore
       decrypt: this.accounts_decrypt,
     });
 
@@ -65,15 +66,15 @@ export class KlaytnWeb3 extends Web3 {
   }
 
   async accounts_decrypt(keystore: KeyStore | string, password: string, options?: Record<string, unknown>){
-		const account = await decrypt(keystore, password, (options?.nonStrict as boolean) ?? true);
+    const account = await decrypt(keystore, password, (options?.nonStrict as boolean) ?? true);
 
-		return {
-			...account,
-      // // TO-DO : decrypt function will be implemented with KeyStore V4 later
-			// signTransaction: async (transaction: Transaction) =>
-			// 	signTransactionWithContext(transaction, account.privateKey),
-		};
-	}
+    return {
+      ...account,
+    // TODO : decrypt function will be implemented with KeyStore V4 later
+    // signTransaction: async (transaction: Transaction) =>
+    // 	signTransactionWithContext(transaction, account.privateKey),
+    };
+  }
 
   accounts_signTransaction(context: Web3Context): typeof this.eth.accounts.signTransaction {
     // signTransactionWithContext. see web3/src/accounts.ts:initAccountsForContext
@@ -84,10 +85,9 @@ export class KlaytnWeb3 extends Web3 {
     };
   }
 
-  accounts_recoverTransaction(context: Web3Context): typeof this.eth.accounts.recoverTransaction {
-    // signTransactionWithContext. see web3/src/accounts.ts:initAccountsForContext
+  accounts_recoverTransaction(): typeof this.eth.accounts.recoverTransaction {
     return (rawTransaction: HexString): Address => {
-      return recoverTransactionWithKlaytnTx(context, rawTransaction);
+      return recoverTransactionWithKlaytnTx(rawTransaction);
     };
   }
 

--- a/web3js-ext/src/web3/web3.ts
+++ b/web3js-ext/src/web3/web3.ts
@@ -7,7 +7,7 @@ import _ from "lodash";
 
 import { prepareTransaction } from "./klaytn_tx";
 import { klay_sendSignedTransaction } from "./send_transaction";
-import { privateKeyToAccount, signTransactionAsFeePayer } from "./account";
+import { privateKeyToAccountWithContext as privateKeyToAccountWithContext, signTransactionAsFeePayer, createWithContext } from "./account";
 
 // TODO: Change the path after web3-core deployed
 const { objectFromRLP } = require("../../../../ethers-ext/dist/src");
@@ -23,6 +23,7 @@ export class KlaytnWeb3 extends Web3 {
     // Override web3.eth.accounts. See web3/src/accounts.ts:initAccountsForContext
     // The functions are bound to 'this' object.
     // TODO: override more web3.eth.accounts methods
+    this.eth.accounts.create = this.accounts_create(this);
     this.eth.accounts.privateKeyToAccount = this.accounts_privateKeyToAccount(this);
     this.eth.accounts.signTransaction = this.accounts_signTransaction(this);
 
@@ -43,10 +44,18 @@ export class KlaytnWeb3 extends Web3 {
 
   // Below methods return a function bound to the context 'web3'.
 
+  accounts_create(context: Web3Context): typeof this.eth.accounts.create {
+
+    return (): Web3Account => {
+      return createWithContext(context);
+    }; 
+  }
+
+
   accounts_privateKeyToAccount(context: Web3Context): typeof this.eth.accounts.privateKeyToAccount {
 
     return (privateKey: Bytes, ignoreLength?: boolean): Web3Account => {
-      return privateKeyToAccount(context, privateKey, ignoreLength);
+      return privateKeyToAccountWithContext(context, privateKey, ignoreLength);
     }; 
   }
 

--- a/web3js-ext/src/web3/web3.ts
+++ b/web3js-ext/src/web3/web3.ts
@@ -30,13 +30,6 @@ export class KlaytnWeb3 extends Web3 {
     this._accountProvider = accounts;
     this._wallet = accounts.wallet;
 
-    // this.eth.accounts.wallet = new Wallet({
-    //   create: this.eth.accounts.create, 
-    //   privateKeyToAccount: this.eth.accounts.privateKeyToAccount,
-    //   // @ts-ignore
-    //   decrypt: this.eth.accounts.decrypt,
-    // });
-
     // New added function for Klaytn
     // @ts-ignore 
     this.eth.accounts.signTransactionAsFeePayer = this.accounts_signTransactionAsFeePayer(this);

--- a/web3js-ext/src/web3/web3.ts
+++ b/web3js-ext/src/web3/web3.ts
@@ -1,5 +1,5 @@
 import Web3, {Bytes, Transaction, Web3Context} from "web3";
-import { signTransaction, SignTransactionResult, privateKeyToAddress } from "web3-eth-accounts";
+import { signTransaction, SignTransactionResult, privateKeyToAddress, Web3Account } from "web3-eth-accounts";
 import { bytesToHex } from "web3-utils";
 import { DataFormat, DEFAULT_RETURN_FORMAT } from "web3-types";
 import { SendTransactionOptions } from "web3-eth";
@@ -7,7 +7,7 @@ import _ from "lodash";
 
 import { prepareTransaction } from "./klaytn_tx";
 import { klay_sendSignedTransaction } from "./send_transaction";
-import { signTransactionAsFeePayer } from "./account";
+import { privateKeyToAccount, signTransactionAsFeePayer } from "./account";
 
 // TODO: Change the path after web3-core deployed
 const { objectFromRLP } = require("../../../../ethers-ext/dist/src");
@@ -23,6 +23,7 @@ export class KlaytnWeb3 extends Web3 {
     // Override web3.eth.accounts. See web3/src/accounts.ts:initAccountsForContext
     // The functions are bound to 'this' object.
     // TODO: override more web3.eth.accounts methods
+    this.eth.accounts.privateKeyToAccount = this.accounts_privateKeyToAccount(this);
     this.eth.accounts.signTransaction = this.accounts_signTransaction(this);
 
     // New added function for Klaytn
@@ -41,6 +42,14 @@ export class KlaytnWeb3 extends Web3 {
   }
 
   // Below methods return a function bound to the context 'web3'.
+
+  accounts_privateKeyToAccount(context: Web3Context): typeof this.eth.accounts.privateKeyToAccount {
+
+    return (privateKey: Bytes, ignoreLength?: boolean): Web3Account => {
+      return privateKeyToAccount(context, privateKey, ignoreLength);
+    }; 
+  }
+
 
   accounts_signTransaction(context: Web3Context): typeof this.eth.accounts.signTransaction {
     // signTransactionWithContext. see web3/src/accounts.ts:initAccountsForContext

--- a/web3js-ext/src/web3/web3.ts
+++ b/web3js-ext/src/web3/web3.ts
@@ -37,7 +37,6 @@ export class KlaytnWeb3 extends Web3 {
     // // TODO: override more web3.eth.accounts methods
     // this.eth.accounts.create = this.accounts_create(this);
     // this.eth.accounts.privateKeyToAccount = this.accounts_privateKeyToAccount(this);
-    // this.eth.accounts.signTransaction = this.accounts_signTransaction(this);
     // this.eth.accounts.recoverTransaction = this.accounts_recoverTransaction();
     // this.eth.accounts.decrypt = this.accounts_decrypt;
 
@@ -85,15 +84,6 @@ export class KlaytnWeb3 extends Web3 {
   //   // TODO : decrypt function will be implemented with KeyStore V4 later
   //   // signTransaction: async (transaction: Transaction) =>
   //   // 	signTransactionWithContext(transaction, account.privateKey),
-  //   };
-  // }
-
-  // accounts_signTransaction(context: Web3Context): typeof this.eth.accounts.signTransaction {
-  //   // signTransactionWithContext. see web3/src/accounts.ts:initAccountsForContext
-  //   return async (transaction: Transaction, privateKey: Bytes): Promise<SignTransactionResult> => {
-  //     let tx = await prepareTransaction(transaction, context, privateKey);
-  //     let priv = bytesToHex(privateKey);
-  //     return signTransaction(tx, priv);
   //   };
   // }
 

--- a/web3js-ext/src/web3/web3.ts
+++ b/web3js-ext/src/web3/web3.ts
@@ -23,16 +23,13 @@ export class KlaytnWeb3 extends Web3 {
     // The Web3 constructor. See web3/src/web3.ts
     super(provider);
 
+    // web3.eth.accounts methods are bound to 'this' object.
     const accounts = initAccountsForContext(this);
 
     this.eth.accounts = accounts;
     this._accountProvider = accounts;
     this._wallet = accounts.wallet;
 
-    // // Override web3.eth.accounts. See web3/src/accounts.ts:initAccountsForContext
-    // // The functions are bound to 'this' object.
-    // // TODO: override more web3.eth.accounts methods
-    // this.eth.accounts.create = this.accounts_create(this);
     // this.eth.accounts.recoverTransaction = this.accounts_recoverTransaction();
     // this.eth.accounts.decrypt = this.accounts_decrypt;
 
@@ -60,11 +57,6 @@ export class KlaytnWeb3 extends Web3 {
 
   // Below methods return a function bound to the context 'web3'.
 
-  // accounts_create(context: Web3Context): typeof this.eth.accounts.create {
-  //   return (): Web3Account => {
-  //     return createWithContext(context);
-  //   }; 
-  // }
 
   // async accounts_decrypt(keystore: KeyStore | string, password: string, options?: Record<string, unknown>){
   //   const account = await decrypt(keystore, password, (options?.nonStrict as boolean) ?? true);


### PR DESCRIPTION
Override the web3.eth.accounts functions to bind with updated functions to support Klaytn features.

- create
- privateKeyToAccount
- signTransaction
- recoverTransaction
- decrypt (To be updated for supporting KeyStore V4) 