### PR TITLE
web3js-ext: Patch the exported path in package.json

### DIFF
--- a/web3js-ext/package.json
+++ b/web3js-ext/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@klaytn/web3js-ext",
     "version": "0.9.8-beta",
-    "main": "dist/src/index.js",
+    "main": "dist/index.js",
     "files": [
         "./dist",
         "./src"
@@ -39,5 +39,4 @@
         "ethereum-cryptography": "^2.1.2",
         "lodash": "^4.17.21"
     }
-    
 }


### PR DESCRIPTION
Fix errors in the exported path of package.json.