### PR TITLE
web3js-ext : version up 0.9.9-beta

### DIFF
--- a/web3js-ext/package.json
+++ b/web3js-ext/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@klaytn/web3js-ext",
-    "version": "0.9.8-beta",
+    "version": "0.9.9-beta",
     "main": "dist/index.js",
     "files": [
         "./dist",


### PR DESCRIPTION
Version upgrade to 0.9.9-beta due to hotfix https://github.com/klaytn/web3klaytn/pull/558. 