### PR TITLE
jscore: Add getPublicKeyFromPrivate

### DIFF
--- a/js-ext-core/package.json
+++ b/js-ext-core/package.json
@@ -31,7 +31,6 @@
     "@types/chai": "^4.3.4",
     "@types/chai-as-promised": "^7.1.5",
     "@types/elliptic": "^6.4.16",
-    "@types/jest": "^29.5.7",
     "@types/lodash": "^4.14.199",
     "@types/mocha": "^10.0.6",
     "@types/node": "^20.8.10",

--- a/js-ext-core/src/util/ec.ts
+++ b/js-ext-core/src/util/ec.ts
@@ -6,10 +6,20 @@ import { HexStr } from "./data";
 
 const secp256k1 = new ec("secp256k1");
 
+// Returns a 33-byte compressed public key from a private key.
+export function getPublicKeyFromPrivate(privateKey: string): string {
+  const key = secp256k1.keyFromPrivate(HexStr.stripHexPrefix(privateKey), "hex");
+  return getCompressedPublicKey(key.getPublic(true, "hex"));
+}
+
 // Returns a 33-byte compressed public key from
 // a compressed (33-byte), uncompressed (65-byte) public key,
 // or an object { x, y } (each 32-byte).
 export function getCompressedPublicKey(pub: any): string {
+  if (pub instanceof Uint8Array) {
+    pub = HexStr.from(pub);
+  }
+
   if (_.isString(pub)) { // Hex string
     const hex = HexStr.from(HexStr.withHexPrefix(pub));
     if (HexStr.isHex(hex, 33) || HexStr.isHex(hex, 65)) {

--- a/js-ext-core/test/util.spec.ts
+++ b/js-ext-core/test/util.spec.ts
@@ -16,6 +16,7 @@ import {
   isFeeDelegationTxType,
   isKlaytnTxType,
   isPartialFeeDelegationTxType,
+  getPublicKeyFromPrivate,
   getCompressedPublicKey,
   getSignatureTuple,
   getRpcTxObject,
@@ -71,6 +72,12 @@ describe("util", () => {
     assert.equal(getKaikasTxType(8), "VALUE_TRANSFER");
     assert.equal(getKaikasTxType("0x09"), "FEE_DELEGATED_VALUE_TRANSFER");
     assert.equal(getKaikasTxType("SMART_CONTRACT_EXECUTION"), "SMART_CONTRACT_EXECUTION");
+  });
+
+  it("getPublicKeyFromPrivate", () => {
+    const priv = "0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8";
+    const pub = "0x03dc9dccbd788c00fa98f7f4082f2f714e799bc0c29d63f04d48b54fe6250453cd";
+    assert.equal(getPublicKeyFromPrivate(priv), pub);
   });
 
   it("getCompressedPublicKey", () => {


### PR DESCRIPTION
- The util function `getPublicKeyFromPrivate` will be useful in composing AccountUpdate transactions.
- Private Key -> Public Key conversion is frustrating in both ethers.js and web3.js

**As-is**

https://github.com/klaytn/web3klaytn/blob/4e6c944cf31f244775ee59fc772ba17680533c19/ethers-ext/example/accountKey/AccountKeyPublic.js#L17

https://github.com/klaytn/web3klaytn/blob/4e6c944cf31f244775ee59fc772ba17680533c19/web3js-ext/example/accountKey/AccountKeyPublic_01_accountUpdate.js#L18

**To-be**

```js
const { getPublicKeyFromPrivate } = require("@klaytn/js-ext-core");
const { getPublicKeyFromPrivate } = require("@klaytn/ethers-ext"); // because ethers-ext exports js-ext-core/util/*
const { getPublicKeyFromPrivate } = require("@klaytn/web3js-ext"); // because web3js-ext exports js-ext-core/util/*

const senderNewPub = getPublicKeyFromPrivate(senderNewPriv);
```