### PR TITLE
added exception handling when dummy feepayer signature is in

### DIFF
--- a/web3py-ext/web3py_ext/transaction/fee_delegation/fee_delegated_account_update_transaction.py
+++ b/web3py-ext/web3py_ext/transaction/fee_delegation/fee_delegated_account_update_transaction.py
@@ -383,12 +383,10 @@ class FeeDelegatedAccountUpdateTransaction(_TypedTransactionImplementation):
 
         # when signing at first time
         transaction_with_signatures = transaction_without_signature_fields
-        if 'feePayerSignatures' not in transaction_without_signature_fields:
+        if 'feePayerSignatures' not in transaction_without_signature_fields or transaction_with_signatures['feePayerSignatures'][0]['v'] == 1:
             transaction_with_signatures = merge(transaction_without_signature_fields, {'feePayerSignatures':[]})
         
-        if vrs != {} and vrs not in transaction_with_signatures['signatures']:
-            transaction_with_signatures['feePayerSignatures'].append(vrs)
-
+        transaction_with_signatures['feePayerSignatures'].append(vrs)
         transaction_with_signatures = pipe(
             transaction_with_signatures,
             apply_formatters_to_dict(KLAYTN_TYPED_TRANSACTION_FORMATTERS),

--- a/web3py-ext/web3py_ext/transaction/fee_delegation/fee_delegated_cancel_transaction.py
+++ b/web3py-ext/web3py_ext/transaction/fee_delegation/fee_delegated_cancel_transaction.py
@@ -343,7 +343,7 @@ class FeeDelegatedCancelTransaction(_TypedTransactionImplementation):
 
         # when signing at first time
         transaction_with_signatures = transaction_without_signature_fields
-        if 'feePayerSignatures' not in transaction_without_signature_fields:
+        if 'feePayerSignatures' not in transaction_without_signature_fields or transaction_with_signatures['feePayerSignatures'][0]['v'] == 1:
             transaction_with_signatures = merge(transaction_without_signature_fields, {'feePayerSignatures':[]})
         
         transaction_with_signatures['feePayerSignatures'].append(vrs)

--- a/web3py-ext/web3py_ext/transaction/fee_delegation/fee_delegated_chaindata_anchoring_transaction.py
+++ b/web3py-ext/web3py_ext/transaction/fee_delegation/fee_delegated_chaindata_anchoring_transaction.py
@@ -349,12 +349,10 @@ class FeeDelegatedChaindataAnchoringTransaction(_TypedTransactionImplementation)
 
         # when signing at first time
         transaction_with_signatures = transaction_without_signature_fields
-        if 'feePayerSignatures' not in transaction_without_signature_fields:
+        if 'feePayerSignatures' not in transaction_without_signature_fields or transaction_with_signatures['feePayerSignatures'][0]['v'] == 1:
             transaction_with_signatures = merge(transaction_without_signature_fields, {'feePayerSignatures':[]})
         
-        if vrs != {} and vrs not in transaction_with_signatures['signatures']:
-            transaction_with_signatures['feePayerSignatures'].append(vrs)
-
+        transaction_with_signatures['feePayerSignatures'].append(vrs)
         transaction_with_signatures = pipe(
             transaction_with_signatures,
             apply_formatters_to_dict(KLAYTN_TYPED_TRANSACTION_FORMATTERS),

--- a/web3py-ext/web3py_ext/transaction/fee_delegation/fee_delegated_smart_contract_deploy_transaction.py
+++ b/web3py-ext/web3py_ext/transaction/fee_delegation/fee_delegated_smart_contract_deploy_transaction.py
@@ -348,12 +348,10 @@ class FeeDelegatedSmartContractDeployTransaction(_TypedTransactionImplementation
 
         # when signing at first time
         transaction_with_signatures = transaction_without_signature_fields
-        if 'signatures' not in transaction_with_signatures:
-            transaction_with_signatures = merge(transaction_with_signatures, {'signatures':[]})
+        if 'feePayerSignatures' not in transaction_without_signature_fields or transaction_with_signatures['feePayerSignatures'][0]['v'] == 1:
+            transaction_with_signatures = merge(transaction_without_signature_fields, {'feePayerSignatures':[]})
         
-        if vrs != {} and vrs not in transaction_with_signatures['signatures']:
-            transaction_with_signatures['signatures'].append(vrs)
-
+        transaction_with_signatures['feePayerSignatures'].append(vrs)
         transaction_with_signatures = pipe(
             transaction_with_signatures,
             apply_formatters_to_dict(KLAYTN_TYPED_TRANSACTION_FORMATTERS),

--- a/web3py-ext/web3py_ext/transaction/fee_delegation/fee_delegated_smart_contract_execution_transaction.py
+++ b/web3py-ext/web3py_ext/transaction/fee_delegation/fee_delegated_smart_contract_execution_transaction.py
@@ -392,7 +392,7 @@ class FeeDelegatedSmartContractExecutionTransaction(_TypedTransactionImplementat
 
         # when signing at first time
         transaction_with_signatures = transaction_without_signature_fields
-        if 'feePayerSignatures' not in transaction_without_signature_fields:
+        if 'feePayerSignatures' not in transaction_without_signature_fields or transaction_with_signatures['feePayerSignatures'][0]['v'] == 1:
             transaction_with_signatures = merge(transaction_without_signature_fields, {'feePayerSignatures':[]})
         
         transaction_with_signatures['feePayerSignatures'].append(vrs)

--- a/web3py-ext/web3py_ext/transaction/fee_delegation/fee_delegated_value_transfer_transaction.py
+++ b/web3py-ext/web3py_ext/transaction/fee_delegation/fee_delegated_value_transfer_transaction.py
@@ -351,7 +351,7 @@ class FeeDelegatedValueTransferTransaction(_TypedTransactionImplementation):
 
         # when signing at first time
         transaction_with_signatures = transaction_without_signature_fields
-        if 'feePayerSignatures' not in transaction_without_signature_fields:
+        if 'feePayerSignatures' not in transaction_without_signature_fields or transaction_with_signatures['feePayerSignatures'][0]['v'] == 1:
             transaction_with_signatures = merge(transaction_without_signature_fields, {'feePayerSignatures':[]})
         
         transaction_with_signatures['feePayerSignatures'].append(vrs)

--- a/web3py-ext/web3py_ext/transaction/fee_delegation/fee_delegated_value_transfer_with_memo_transaction.py
+++ b/web3py-ext/web3py_ext/transaction/fee_delegation/fee_delegated_value_transfer_with_memo_transaction.py
@@ -356,7 +356,7 @@ class FeeDelegatedValueTransferWithMemoTransaction(_TypedTransactionImplementati
 
         # when signing at first time
         transaction_with_signatures = transaction_without_signature_fields
-        if 'feePayerSignatures' not in transaction_without_signature_fields:
+        if 'feePayerSignatures' not in transaction_without_signature_fields or transaction_with_signatures['feePayerSignatures'][0]['v'] == 1:
             transaction_with_signatures = merge(transaction_without_signature_fields, {'feePayerSignatures':[]})
         
         transaction_with_signatures['feePayerSignatures'].append(vrs)


### PR DESCRIPTION
- web3py-ext
  - feePayer dummy data case occurs when a user sign the transaction with Kaikas