### PR TITLE
web3js: Keystore v4 (KIP-3) support

### DIFF
--- a/ethers-ext/test/keystore.spec.ts
+++ b/ethers-ext/test/keystore.spec.ts
@@ -1,4 +1,5 @@
 import { assert } from "chai";
+import { describe, it } from "mocha";
 
 import { decryptKeystoreList, decryptKeystoreListSync } from "../src";
 

--- a/web3js-ext/README.md
+++ b/web3js-ext/README.md
@@ -58,11 +58,10 @@ See [DESIGN](./DESIGN.md) for source code organization.
   account.signTransaction(obj or rlp)
   account.signTransactionAsFeePayer(obj or rlp)
   ```
-- (TODO) Following functions can handle the [KIP-3 Klaytn keystore format v4](https://kips.klaytn.foundation/KIPs/kip-3)
+- Following functions can handle the [KIP-3 Klaytn keystore format v4](https://kips.klaytn.foundation/KIPs/kip-3)
   ```js
   web3.eth.accounts.decrypt(keystore)
   web3.eth.accounts.decryptList(keystore)
-  web3.eth.accounts.wallet.decrypt(keystore)
   ```
 
 ### Eth RPC wrappers

--- a/web3js-ext/src/accounts/index.ts
+++ b/web3js-ext/src/accounts/index.ts
@@ -1,5 +1,5 @@
 import { Web3Context } from "web3-core";
-import { encrypt, hashMessage, recover, sign, Wallet } from "web3-eth-accounts";
+import { encrypt, hashMessage, recover, sign } from "web3-eth-accounts";
 import { EthExecutionAPI } from "web3-types";
 
 import { KlaytnAccountsInterface } from "../types";
@@ -7,6 +7,7 @@ import { KlaytnAccountsInterface } from "../types";
 import { context_create, context_privateKeyToAccount, context_decrypt, context_decryptList } from "./create";
 import { recoverTransaction } from "./recover";
 import { context_signTransaction, context_signTransactionAsFeePayer } from "./sign";
+import { Wallet } from "./wallet";
 
 
 // Analogous to: web3/src/accounts.ts:initAccountsForContext

--- a/web3js-ext/src/accounts/index.ts
+++ b/web3js-ext/src/accounts/index.ts
@@ -4,7 +4,7 @@ import { EthExecutionAPI } from "web3-types";
 
 import { KlaytnAccountsInterface } from "../types";
 
-import { context_create, context_privateKeyToAccount, context_decrypt } from "./create";
+import { context_create, context_privateKeyToAccount, context_decrypt, context_decryptList } from "./create";
 import { recoverTransaction } from "./recover";
 import { context_signTransaction, context_signTransactionAsFeePayer } from "./sign";
 
@@ -17,6 +17,7 @@ export function context_accounts(context: Web3Context<EthExecutionAPI>): KlaytnA
   const _create = context_create(context);
   const _privateKeyToAccount = context_privateKeyToAccount(context);
   const _decrypt = context_decrypt(context);
+  const _decryptList = context_decryptList(context);
 
   return {
     recoverTransaction,
@@ -28,6 +29,7 @@ export function context_accounts(context: Web3Context<EthExecutionAPI>): KlaytnA
     create: _create,
     privateKeyToAccount: _privateKeyToAccount,
     decrypt: _decrypt,
+    decryptList: _decryptList,
     signTransaction: _signTransaction,
     signTransactionAsFeePayer: _signTransactionAsFeePayer,
 

--- a/web3js-ext/src/accounts/wallet.ts
+++ b/web3js-ext/src/accounts/wallet.ts
@@ -1,0 +1,26 @@
+
+import { isKIP3Json } from "@klaytn/js-ext-core";
+import { Wallet as EthWallet } from "web3-eth-accounts";
+import { Web3BaseWalletAccount, KeyStore } from "web3-types";
+
+import { KlaytnWeb3Account } from "../types";
+
+export class Wallet<
+	T extends Web3BaseWalletAccount = KlaytnWeb3Account,
+> extends EthWallet<T> {
+  public async decrypt(
+    encryptedWallets: KeyStore[],
+    password: string,
+    options?: Record<string, unknown> | undefined,
+  ) {
+    const keystores = encryptedWallets.map((wallet) => JSON.stringify(wallet));
+    for (const keystore of keystores) {
+      if (isKIP3Json(keystore)) {
+        // Do not support because KIP-3 keystores contain multiple keys for the same address,
+        // but Wallet assumes an account is uniquely identified by its address.
+        throw new Error("KIP-3 (v4) keystores unsupported in Wallet. Use web3.eth.accounts.decrypt and web3.eth.accounts.decryptList instead.");
+      }
+    }
+    return super.decrypt(encryptedWallets, password, options);
+  }
+}

--- a/web3js-ext/src/types.ts
+++ b/web3js-ext/src/types.ts
@@ -121,6 +121,11 @@ export interface KlaytnAccountsInterface {
 			transaction: KlaytnTransaction | string,
 			privateKey: Bytes,
 		) => ReturnType<typeof signTransaction>;
+		decryptList: (
+			keystore: string,
+			password: string,
+			options?: Record<string, unknown>,
+		) => Promise<KlaytnWeb3Account[]>;
 }
 
 // The plain Transaction object supplied by the users.

--- a/web3js-ext/src/types.ts
+++ b/web3js-ext/src/types.ts
@@ -101,9 +101,9 @@ export interface KlaytnAccountsInterface {
 		sign: typeof sign;
 		recover: typeof recover;
 		encrypt: typeof encrypt;
-		wallet: Wallet;
 
 		// Klaytn: modified methods
+		wallet: Wallet<KlaytnWeb3Account>;
 		create: () => KlaytnWeb3Account;
 		privateKeyToAccount: (privateKey: Uint8Array | string) => KlaytnWeb3Account;
 		decrypt: (

--- a/web3js-ext/test/account.spec.ts
+++ b/web3js-ext/test/account.spec.ts
@@ -26,6 +26,30 @@ const txSignatures = [["0x7f5", "0x9f8e49e2ad84b0732984398749956e807e4b526c786af
 const tx0 = { type: 0, from, to, value, gasPrice };
 const tx9 = { type: 9, from, to, value, gasPrice, txSignatures };
 const lightKdf: CipherOptions = { kdf: "scrypt", n: 2, p: 1 }; // For faster testing
+
+const keystores = [
+  { // Eth V3. ethers.Wallet.createRandom().encrypt("password")
+    json: '{"address":"029e786304c1531af3ac7db24a02448e543a099e","id":"9d492c95-b9e3-42e3-af73-5c77e932208d","version":3,"crypto":{"cipher":"aes-128-ctr","cipherparams":{"iv":"bfcb88a1501e2bb1e6694c03da18953d"},"ciphertext":"076510b4e25d5cfc31239bffcad6036fe543cbbb04b9f3ec719bf4f61b58fc05","kdf":"scrypt","kdfparams":{"salt":"79124f05995aae98b3088d8365f59a6dfadd1c9ed249abae3c07733f4cbbee53","n":131072,"dklen":32,"p":1,"r":8},"mac":"d70f83824c2c30dc5cd3a244d87147b6aa713a6000165789a82a467651284ac7"}}',
+    password: "password",
+    address: "0x029e786304c1531aF3aC7db24A02448e543A099E",
+    keys: ["0x1b33a48f58d8c85ab142a7375fcf18714d88271f6647cfa6b54f1be66b05a762"],
+  },
+  { // Klaytn V4 with one key. kcn account new --lightkdf
+    json: '{"address":"ec5eaa07b4d3cbafe7bf437a1ea9a898209f617c","keyring":[[{"cipher":"aes-128-ctr","ciphertext":"0a5aa3749b9e83c2a4238445aeb66f59355c0363a54c163e34e454f76e061e47","cipherparams":{"iv":"2a0b2e02a61e0f721bd800ea6e23a588"},"kdf":"scrypt","kdfparams":{"dklen":32,"n":4096,"p":6,"r":8,"salt":"538ead57745bcd946b05fe294de08256628d9a0a393fd29ced933ba5fc045b07"},"mac":"30b5488bc97165bc7ecac8ff8dfec65a75a8ad206450aecff0ac2dfea6f79b08"}]],"id":"362c0766-f5e3-4b4d-af22-7e89d5fb613a","version":4}',
+    password: "password",
+    address: "0xEc5eAa07b4d3CbAfe7bf437a1Ea9A898209F617c",
+    keys: ["0x4062512193ef1dab8ccf3e3d7a4862e3c740bdf11d852954ed48bc73643e354f"],
+  },
+  { // Klaytn V4 with multiple role-based keys. https://toolkit.klaytn.foundation/misc/generateKeystore
+    json: '{"version":4,"id":"2d7ad5c1-880f-4920-9b8e-51f852c4802c","address":"0x17226c9b4e130551c258eb7b1cdc927c13998cd6","keyring":[[{"ciphertext":"eb9bd884ac3cc8bf92e6b0082e9d07198bfc4c1223ccc6e5edf7452ad612b2b5","cipherparams":{"iv":"47faf7b0991a051eef698c73fc246f78"},"cipher":"aes-128-ctr","kdf":"scrypt","kdfparams":{"dklen":32,"salt":"ba0a3e8dc49a04f8e590f8df5a590bc6e134b031ce10f46d73d4c459aa4c08f8","n":4096,"r":8,"p":1},"mac":"4978d7325e1b9b3ec9fdfd1ec709a5a86fdfade0297ea9ddeeb8c3a7a62ae898"}],[{"ciphertext":"1a80c8666bea1a8dfa3082b001ff64c818fb14cf4e02017785e0edcc7a277af4","cipherparams":{"iv":"eafbecc65ccc177a5579bf56d5f4ed31"},"cipher":"aes-128-ctr","kdf":"scrypt","kdfparams":{"dklen":32,"salt":"6472845219e11e4de094cac8c32a6a4d13e69cd4507780a7a37f5e411e1d895d","n":4096,"r":8,"p":1},"mac":"86379236d2fd6e9bb3f99f7eebaa3325b51e9fa5ec150ade7a461555c0a14ca3"},{"ciphertext":"0071c41d2956b12be5ebc08a9a5b3a9684b9e410fe2de91d614be977fb2a0bdb","cipherparams":{"iv":"1492dfb771030d3d9c9d996c193c03e5"},"cipher":"aes-128-ctr","kdf":"scrypt","kdfparams":{"dklen":32,"salt":"f8145aa907a649866e0fbff86011244584ddc86559cf4901f8f69b670c234fd7","n":4096,"r":8,"p":1},"mac":"eacc58c1ad717ca375697c9fcc80f463a26600f5da1b21327715bf3efa047be5"}],[{"ciphertext":"68ffc1e2800a7288ba7baba0f0f8049daeed05379fabfdd3bc017fa85c49ab50","cipherparams":{"iv":"17f22d7b8aa1a8a2948fd3629f0b89ed"},"cipher":"aes-128-ctr","kdf":"scrypt","kdfparams":{"dklen":32,"salt":"ff5e577ec8294320cfe59ef7b1b01ee44d4c9f19c8fbc31f333059c74eb8c6d2","n":4096,"r":8,"p":1},"mac":"de65d669be044df5e39e678b099424a8692a2da6f3746832862cf2e5d6ada612"},{"ciphertext":"fd4810ee850f0aa5f61a2eafbfc5ca36cfebb42df5c2465cc8ae5188029b188b","cipherparams":{"iv":"b00ead13b38e449c268d09fced80ce49"},"cipher":"aes-128-ctr","kdf":"scrypt","kdfparams":{"dklen":32,"salt":"af5dbbfb7383045dc7f8a3bfc56cccfc22a5150a1f87e454d40893a4b6fea9a1","n":4096,"r":8,"p":1},"mac":"6234352852eb18246b94f28f3c3454103289ecf2faaa91115927c53729bb0805"},{"ciphertext":"03b758de6372aa6bedde513ccb282bf8af32bca227c258f3e0fc85ce454d72a4","cipherparams":{"iv":"5c20f3e96d0802eaf56670e57fbe3e98"},"cipher":"aes-128-ctr","kdf":"scrypt","kdfparams":{"dklen":32,"salt":"b5ec4e40f5a09a59e90317ce45eb7bcd73a2a9afe70f6f2e32548fd38ed2da3b","n":4096,"r":8,"p":1},"mac":"99b7f59855f0aa04531cc4a24c7923f75ed8052084de9ec49a2794e3899c3274"}]]}',
+    password: "password",
+    address: "0x17226c9B4e130551c258Eb7B1Cdc927c13998cd6",
+    keys: [
+      "0x278c3d035328daf04ab2597da96dd2d8868fd61a8837030f7d8a85f27b7f1bad",
+      "0xa06d13800719307ea7e2503ea441c2ea49279d0d600a2eec2887b50928869676", "0xc32f4007ffad303db99dee0d79a720e1d70c4b2babf8e33cb28170a16bac467d",
+      "0xc274d13302891d0d91a60891a48fde8c2860018f8dcb6293dcc0b28a238590b0", "0x83c127e5207b70086a702c93f1c9a041f15ce49ee5183ce848f35c64de196eff", "0x48f97204ac4886dfbd819ada04ea31a730c6fc43fcb08900566360ee7402f93b"],
+  }
+];
 /* eslint-enable quotes */
 
 
@@ -145,12 +169,22 @@ describe("web3.eth.accounts", () => {
   });
 
   it("decrypt()", async () => {
-    const json = "{\"address\":\"3c44cdddb6a900fa2b585dd299e03d12fa4293bc\",\"id\":\"3d73e4aa-2102-4203-8f90-2fb1b0690af7\",\"version\":3,\"crypto\":{\"cipher\":\"aes-128-ctr\",\"cipherparams\":{\"iv\":\"c65d46f512e3e3c66729cdec6884123c\"},\"ciphertext\":\"32f222a3b6f454559331f04f0645b76733e924c770bfe311d6a80a11b952c97a\",\"kdf\":\"scrypt\",\"kdfparams\":{\"salt\":\"317e916c3caa8da89868c41300ec8e2eba88abc2474ee5f7954ba757e7c81caf\",\"n\":2,\"dklen\":32,\"p\":1,\"r\":8},\"mac\":\"36ed4164aab7f139aa42990d11d7f790078f454b46a4d4d0b9ed718de2dd3e9a\"},\"x-ethers\":{\"client\":\"ethers.js\",\"gethFilename\":\"UTC--2023-11-29T09-26-20.0Z--3c44cdddb6a900fa2b585dd299e03d12fa4293bc\",\"mnemonicCounter\":\"6c3b6d22c9e7361b65043ef05430febd\",\"mnemonicCiphertext\":\"63bd4059afc9294ae4e748cf5cee4b61\",\"path\":\"m/44'/60'/0'/0/2\",\"locale\":\"en\",\"version\":\"0.1\"}}";
-    const priv = "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a";
-    const addr = "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC";
+    for (const tc of keystores) {
+      const version = JSON.parse(tc.json).version;
+      if (version == 3) {
+        await checkAccountObject(await EW3.eth.accounts.decrypt(tc.json, tc.password), tc.address, tc.keys[0]);
+      }
+      await checkAccountObject(await KW3.eth.accounts.decrypt(tc.json, tc.password), tc.address, tc.keys[0]);
+    }
+  });
 
-    await checkAccountObject(await EW3.eth.accounts.decrypt(json, ""), addr, priv);
-    await checkKlaytnAccountObject(await KW3.eth.accounts.decrypt(json, ""), addr, priv);
+  it("decryptList()", async () => {
+    for (const tc of keystores) {
+      const accounts = await KW3.eth.accounts.decryptList(tc.json, tc.password);
+      for (let idx = 0; idx < accounts.length; idx++) {
+        await checkKlaytnAccountObject(accounts[idx], tc.address, tc.keys[idx]);
+      }
+    }
   });
 
   it("signTransaction()", async () => {

--- a/web3js-ext/test/account.spec.ts
+++ b/web3js-ext/test/account.spec.ts
@@ -148,7 +148,7 @@ describe("web3.eth.accounts", () => {
     }
     async function checkKlaytnWallet(W3: KlaytnWeb3) {
       await checkWallet(W3);
-      checkKlaytnAccountObject(W3.eth.accounts.wallet.at(0) as KlaytnWeb3Account); // TODO: fix type
+      checkKlaytnAccountObject(W3.eth.accounts.wallet.at(0)!);
     }
 
     await checkWallet(EW3);


### PR DESCRIPTION
- `web3.eth.accounts.decrypt` can parse v4, return the first account.
- `web3.eth.accounts.decryptList` can parse v4, return all accounts.
- `web3.eth.accounts.wallet.decrypt` explicitly throws when v4 is given.
	- Why not support v4? because web3 wallet uniquely identifies an account by its address. It’s confusing to support (1 address + many keys). We will not support v4 keystore until we have a good solution (e.g. AccountStore).