### PR TITLE
jscore: Add parseAccountKey, Fix parseTransaction and parseTxType

### DIFF
--- a/ethers-ext/example/accountKey/AccountKeyLegacy.js
+++ b/ethers-ext/example/accountKey/AccountKeyLegacy.js
@@ -5,8 +5,8 @@ const { ethers } = require("ethers");
 
 const { Wallet } = require("@klaytn/ethers-ext");
 
-const senderAddr = "0xa2a8854b1802d8cd5de631e690817c253d6a9153";
-const senderPriv = "0x0e4ca6d38096ad99324de0dde108587e5d7c600165ae4cd6c2462c597458c2b8";
+const senderAddr = "0x24e8efd18d65bcb6b3ba15a4698c0b0d69d13ff7";
+const senderPriv = "0x4a72b3d09c3d5e28e8652e0111f9c4ce252e8299aad95bb219a38eb0a3f4da49";
 const recieverAddr = "0xc40b6909eb7085590e1c26cb3becc25368e249e9";
 
 const provider = new ethers.providers.JsonRpcProvider("https://public-en-baobab.klaytn.net");

--- a/js-ext-core/src/accountkey/factory.ts
+++ b/js-ext-core/src/accountkey/factory.ts
@@ -25,3 +25,30 @@ class _AccountKeyFactory extends FieldSetFactory<AccountKey> {
   }
 }
 export const AccountKeyFactory = new _AccountKeyFactory();
+
+export interface ParsedAccountKeyNil { type: AccountKeyType.Nil; }
+export interface ParsedAccountKeyLegacy { type: AccountKeyType.Legacy; }
+export interface ParsedAccountKeyPublic { type: AccountKeyType.Public; key: string; }
+export interface ParsedAccountKeyFail { type: AccountKeyType.Fail; }
+export interface ParsedAccountKeyWeightedMultiSig {
+  type: AccountKeyType.WeightedMultiSig;
+  threshold: number;
+  keys: { weight: number, key: string }[];
+}
+export type ParsedAccountKeyEmbeddable =
+  | ParsedAccountKeyNil
+  | ParsedAccountKeyLegacy
+  | ParsedAccountKeyPublic
+  | ParsedAccountKeyFail
+  | ParsedAccountKeyWeightedMultiSig;
+export interface ParsedAccountKeyRoleBased {
+  type: AccountKeyType.RoleBased;
+  keys: ParsedAccountKeyEmbeddable[];
+}
+export type ParsedAccountKey =
+  | ParsedAccountKeyEmbeddable
+  | ParsedAccountKeyRoleBased;
+
+export function parseAccountKey(rlp: string): ParsedAccountKey {
+  return { type: 0 };
+}

--- a/js-ext-core/src/accountkey/factory.ts
+++ b/js-ext-core/src/accountkey/factory.ts
@@ -1,11 +1,15 @@
+import { hexValue } from "@ethersproject/bytes";
+
 import { FieldSet, FieldSetFactory, Fields } from "../field";
-import { AccountKeyType } from "../util";
+import { AccountKeyType, HexStr, RLP, getTypePrefix, isKlaytnAccountKeyType } from "../util";
 
 // A typed AccountKey for Klatyn is a FieldSet.
 // https://docs.klaytn.foundation/content/klaytn/design/accounts
 export abstract class AccountKey extends FieldSet {
   // RLP encoding for constructing AccountUpdate transactions.
   abstract toRLP(): string;
+  // Set its own fields from an RLP encoded string.
+  abstract setFieldsFromRLP(rlp: string): void;
 }
 
 class _AccountKeyFactory extends FieldSetFactory<AccountKey> {
@@ -22,6 +26,22 @@ class _AccountKeyFactory extends FieldSetFactory<AccountKey> {
       fields.keys = fields.weightedPublicKeys;
     }
     return super.fromObject(fields);
+  }
+
+  public fromRLP(rlp: string): AccountKey {
+    if (rlp == "0x80") { // special case without type prefix
+      return this.fromObject({ type: AccountKeyType.Nil });
+    }
+
+    const type = getTypePrefix(rlp);
+    if (!isKlaytnAccountKeyType(type)) {
+      throw new Error("Not a Klaytn account key");
+    }
+
+    const ctor = this.lookup(type);
+    const instance = new ctor();
+    instance.setFieldsFromRLP(rlp);
+    return instance;
   }
 }
 export const AccountKeyFactory = new _AccountKeyFactory();
@@ -50,5 +70,28 @@ export type ParsedAccountKey =
   | ParsedAccountKeyRoleBased;
 
 export function parseAccountKey(rlp: string): ParsedAccountKey {
-  return { type: 0 };
+  const key = AccountKeyFactory.fromRLP(rlp);
+  const canonical = key.toObject();
+
+  if (key.type == AccountKeyType.Nil || key.type == AccountKeyType.Legacy || key.type == AccountKeyType.Fail) {
+    return { type: key.type };
+  }
+  if (key.type == AccountKeyType.Public) {
+    return { type: key.type, key: canonical.key };
+  }
+  if (key.type == AccountKeyType.WeightedMultiSig) {
+    return {
+      type: key.type,
+      threshold: HexStr.toNumber(canonical.threshold),
+      keys: canonical.keys.map((k: any) => ({ weight: HexStr.toNumber(k[0]), key: k[1] })),
+    };
+  }
+  if (key.type == AccountKeyType.RoleBased) {
+    return {
+      type: key.type,
+      keys: canonical.keys.map((k: any) => parseAccountKey(k)),
+    };
+  }
+
+  throw new Error(`Unknown AccountKeyType ${key.type}`);
 }

--- a/js-ext-core/src/field/fieldset.ts
+++ b/js-ext-core/src/field/fieldset.ts
@@ -93,6 +93,10 @@ export abstract class FieldSet {
   public toObject(): Fields {
     return this.fields;
   }
+
+  throwTypeError(msg: string): never {
+    throw new Error(`${msg} for '${this.typeName}' (type ${HexStr.fromNumber(this.type)})`);
+  }
 }
 
 // Instantiable child class of TypedFields

--- a/js-ext-core/src/tx/factory.ts
+++ b/js-ext-core/src/tx/factory.ts
@@ -1,4 +1,7 @@
-import { parse as parseEthTransaction, Transaction as EthersTransaction } from "@ethersproject/transactions";
+import { getAddress } from "@ethersproject/address";
+import { hexValue } from "@ethersproject/bytes";
+import { keccak256 } from "@ethersproject/keccak256";
+import { AccessList, parse as parseEthTransaction } from "@ethersproject/transactions";
 import _ from "lodash";
 
 import { FieldSet, FieldSetFactory, Fields } from "../field";
@@ -144,8 +147,8 @@ class _KlaytnTxFactory extends FieldSetFactory<KlaytnTx> {
     }
     // In TxTypeSmartContractDeploy, force 'to' = 0x for compatibility
     if (HexStr.fromNumber(fields.type) == HexStr.fromNumber(TxType.SmartContractDeploy) ||
-        HexStr.fromNumber(fields.type) == HexStr.fromNumber(TxType.FeeDelegatedSmartContractDeploy) ||
-        HexStr.fromNumber(fields.type) == HexStr.fromNumber(TxType.FeeDelegatedSmartContractDeployWithRatio)) {
+      HexStr.fromNumber(fields.type) == HexStr.fromNumber(TxType.FeeDelegatedSmartContractDeploy) ||
+      HexStr.fromNumber(fields.type) == HexStr.fromNumber(TxType.FeeDelegatedSmartContractDeployWithRatio)) {
       fields.to = "0x";
     }
     return super.fromObject(fields);
@@ -165,11 +168,97 @@ class _KlaytnTxFactory extends FieldSetFactory<KlaytnTx> {
 }
 export const KlaytnTxFactory = new _KlaytnTxFactory();
 
-export function parseTransaction(rlp: string): EthersTransaction {
+// Similar to ethers.js 'Transaction', but does not use BigNumber.
+// All numbers are hexlified without leading zeros, suitable for RPC calls.
+export interface ParsedTransaction {
+  hash?: string;
+
+  to?: string;
+  from?: string;
+  nonce: number;
+
+  gasLimit: string;
+  gasPrice?: string;
+
+  data: string;
+  value: string;
+  chainId?: number;
+
+  r?: string;
+  s?: string;
+  v?: number;
+
+  // Typed-Transaction features
+  type?: number | null;
+
+  // EIP-2930; Type 1 & EIP-1559; Type 2
+  accessList?: AccessList;
+
+  // EIP-1559; Type 2
+  maxPriorityFeePerGas?: string;
+  maxFeePerGas?: string;
+
+  // Klaytn tx types
+  key?: any;
+  feePayer?: string;
+  txSignatures?: any;
+  feePayerSignatures?: any;
+  feeRatio?: number;
+}
+
+/* eslint-disable no-multi-spaces */
+export function parseTransaction(rlp: string): ParsedTransaction {
   const type = getTypePrefix(rlp);
   if (!isKlaytnTxType(type)) {
-    return parseEthTransaction(rlp);
+    const tx = parseEthTransaction(rlp);
+    const parsedTx: ParsedTransaction = {
+      ...tx,
+      // Convert BigNumber to hex string
+      gasLimit:             hexValue(tx.gasLimit),
+      gasPrice:             tx.gasPrice ? hexValue(tx.gasPrice) : undefined,
+      value:                hexValue(tx.value),
+      maxPriorityFeePerGas: tx.maxPriorityFeePerGas ? hexValue(tx.maxPriorityFeePerGas) : undefined,
+      maxFeePerGas:         tx.maxFeePerGas ? hexValue(tx.maxFeePerGas) : undefined,
+    };
+    // Clean up 'explicit undefined' fields
+    _.forOwn(parsedTx, (value, key) => {
+      if (value === undefined) {
+        delete (parsedTx as any)[key];
+      }
+    });
+    return parsedTx;
   } else {
-    return KlaytnTxFactory.fromRLP(rlp).toObject() as EthersTransaction;
+    const tx = KlaytnTxFactory.fromRLP(rlp).toObject();
+    try {
+      const parsedTx: ParsedTransaction = {
+        hash:               keccak256(rlp),
+        to:                 tx.to ? getAddress(tx.to) : undefined,
+        from:               tx.from ? getAddress(tx.from) : undefined,
+        nonce:              HexStr.toNumber(tx.nonce),
+        gasLimit:           hexValue(tx.gasLimit),
+        gasPrice:           hexValue(tx.gasPrice),
+        data:               tx.data ?? "0x",
+        value:              hexValue(tx.value ?? 0),
+        chainId:            tx.chainId ? HexStr.toNumber(tx.chainId) : undefined,
+        type:               tx.type ? HexStr.toNumber(tx.type) : null,
+        accessList:         tx.accessList,
+        key:                tx.key,
+        feePayer:           tx.feePayer ? getAddress(tx.feePayer) : undefined,
+        txSignatures:       tx.txSignatures,
+        feePayerSignatures: tx.feePayerSignatures,
+        feeRatio:           tx.feeRatio ? HexStr.toNumber(tx.feeRatio) : undefined,
+      };
+      // Clean up 'explicit undefined' fields
+      _.forOwn(parsedTx, (value, key) => {
+        if (value === undefined) {
+          delete (parsedTx as any)[key];
+        }
+      });
+      return parsedTx;
+    } catch (e) {
+      // In case conversion fails, return the original tx object.
+      return tx as any;
+    }
   }
 }
+/* eslint-enable no-multi-spaces */

--- a/js-ext-core/src/tx/factory.ts
+++ b/js-ext-core/src/tx/factory.ts
@@ -5,19 +5,7 @@ import { AccessList, parse as parseEthTransaction } from "@ethersproject/transac
 import _ from "lodash";
 
 import { FieldSet, FieldSetFactory, Fields } from "../field";
-import { HexStr, getSignatureTuple, SignatureLike, isKlaytnTxType, isFeePayerSigTxType, RLP, TxType } from "../util";
-
-function getTypePrefix(rlp: string) {
-  if (!HexStr.isHex(rlp)) {
-    throw new Error("Not an RLP encoded string");
-  }
-
-  if (rlp.length < 4) {
-    throw new Error("RLP encoded string too short");
-  }
-
-  return HexStr.toNumber(rlp.substring(0, 4)); // 0xNN
-}
+import { HexStr, getTypePrefix, getSignatureTuple, SignatureLike, isKlaytnTxType, isFeePayerSigTxType, RLP, TxType } from "../util";
 
 export abstract class KlaytnTx extends FieldSet {
   // A Klaytn Tx has 4 kinds of RLP encoding:
@@ -59,10 +47,6 @@ export abstract class KlaytnTx extends FieldSet {
 
   // //////////////////////////////////////////////////////////
   // Child classes CANNOT override below methods
-
-  throwTypeError(msg: string): never {
-    throw new Error(`${msg} for '${this.typeName}' (type ${HexStr.fromNumber(this.type)})`);
-  }
 
   // Add a signature
   addSenderSig(sig: SignatureLike) {

--- a/js-ext-core/src/util/const.ts
+++ b/js-ext-core/src/util/const.ts
@@ -31,9 +31,15 @@ export enum TxType {
 
 // Parse Klaytn TxType in various formats including number (8),
 // hex string (0x08), camel case string ("ValueTransfer"), and snake case string ("VALUE_TRANSFER").
-export function parseTxType(type?: number | string): number {
-  if (type == undefined) {
-    return 0;
+type TxTypeLike = number | bigint | string | null | undefined;
+
+export function parseTxType(type?: TxTypeLike): number {
+  if (type === undefined || type === null) {
+    type = 0;
+  }
+
+  if (typeof type === "bigint") {
+    type = Number(type);
   }
 
   if (_.isNumber(type)) {
@@ -63,7 +69,7 @@ export function parseTxType(type?: number | string): number {
 // Convert Klaytn TxType to what Kaikas wallet (https://docs.kaikas.io/) understands.
 // Pass-through undefined and non-Klaytn TxTypes.
 // Convert Klaytn TxTypes to upper and snake case string (e.g. "VALUE_TRANSFER").
-export function getKaikasTxType(type?: number | string): number | string | undefined {
+export function getKaikasTxType(type?: TxTypeLike): number | string | undefined {
   const num = parseTxType(type);
   if (!isKlaytnTxType(num)) {
     return num;

--- a/js-ext-core/src/util/data.ts
+++ b/js-ext-core/src/util/data.ts
@@ -38,3 +38,15 @@ export const HexStr = {
     return value.replace(/^(0x)?/, "");
   }
 };
+
+export function getTypePrefix(rlp: string) {
+  if (!HexStr.isHex(rlp)) {
+    throw new Error("Not an RLP encoded string");
+  }
+
+  if (rlp.length < 4) {
+    throw new Error("RLP encoded string too short");
+  }
+
+  return HexStr.toNumber(rlp.substring(0, 4)); // 0xNN
+}

--- a/js-ext-core/test/accountkey.spec.ts
+++ b/js-ext-core/test/accountkey.spec.ts
@@ -1,7 +1,9 @@
 import { assert } from "chai";
+import _ from "lodash";
 import { describe, it } from "mocha";
 
 import {
+  AccountKey,
   AccountKeyFactory,
   AccountKeyNil,
   AccountKeyLegacy,
@@ -9,67 +11,163 @@ import {
   AccountKeyFail,
   AccountKeyWeightedMultiSig,
   AccountKeyRoleBased,
+  parseAccountKey,
+  AccountKeyType,
 } from "../src";
 
+interface TestCase {
+  title?: string,
+  clazz: typeof AccountKey,
+  object: any,
+  canonical: any,
+  rlp: string,
+}
+
+const testcases: TestCase[] = [
+  {
+    clazz: AccountKeyNil,
+    object: { type: 0 },
+    canonical: { type: "0x" },
+    rlp: "0x80",
+  },
+  {
+    clazz: AccountKeyLegacy,
+    object: { type: 1 },
+    canonical: { type: "0x01" },
+    rlp: "0x01c0",
+  },
+  {
+    clazz: AccountKeyPublic,
+    object: {
+      type: AccountKeyType.Public,
+      key: "0x02dbac81e8486d68eac4e6ef9db617f7fbd79a04a3b323c982a09cdfc61f0ae0e8",
+    },
+    canonical: {
+      type: "0x02",
+      key: "0x02dbac81e8486d68eac4e6ef9db617f7fbd79a04a3b323c982a09cdfc61f0ae0e8",
+    },
+    rlp: "0x02a102dbac81e8486d68eac4e6ef9db617f7fbd79a04a3b323c982a09cdfc61f0ae0e8",
+  },
+  {
+    clazz: AccountKeyFail,
+    object: { type: 3 },
+    canonical: { type: "0x03" },
+    rlp: "0x03c0",
+  },
+  {
+    clazz: AccountKeyWeightedMultiSig,
+    object: {
+      type: AccountKeyType.WeightedMultiSig,
+      threshold: 7,
+      keys: [
+        { weight: 1, key: "0x02c734b50ddb229be5e929fc4aa8080ae8240a802d23d3290e5e6156ce029b110e" },
+        { weight: 2, key: "0x0212d45f1cc56fbd6cd8fc877ab63b5092ac77db907a8a42c41dad3e98d7c64dfb" },
+        { weight: 3, key: "0x02ea9a9f85065a00d7b9ffd3a8532a574035984587fd08107d8f4cbad6b786b0cd" },
+        { weight: 4, key: "0x038551bc489d62fa2e6f767ba87fe93a62b679fca8ff3114eb5805e6487b51e8f6" },
+      ]
+    },
+    canonical: {
+      type: "0x04",
+      threshold: "0x07",
+      keys: [
+        ["0x01", "0x02c734b50ddb229be5e929fc4aa8080ae8240a802d23d3290e5e6156ce029b110e"],
+        ["0x02", "0x0212d45f1cc56fbd6cd8fc877ab63b5092ac77db907a8a42c41dad3e98d7c64dfb"],
+        ["0x03", "0x02ea9a9f85065a00d7b9ffd3a8532a574035984587fd08107d8f4cbad6b786b0cd"],
+        ["0x04", "0x038551bc489d62fa2e6f767ba87fe93a62b679fca8ff3114eb5805e6487b51e8f6"]
+      ]
+    },
+    rlp: "0x04f89307f890e301a102c734b50ddb229be5e929fc4aa8080ae8240a802d23d3290e5e6156ce029b110ee302a10212d45f1cc56fbd6cd8fc877ab63b5092ac77db907a8a42c41dad3e98d7c64dfbe303a102ea9a9f85065a00d7b9ffd3a8532a574035984587fd08107d8f4cbad6b786b0cde304a1038551bc489d62fa2e6f767ba87fe93a62b679fca8ff3114eb5805e6487b51e8f6",
+  },
+  {
+    clazz: AccountKeyRoleBased,
+    object: {
+      type: 5,
+      keys: [
+        {
+          type: AccountKeyType.Public,
+          key: "0x03e4a01407460c1c03ac0c82fd84f303a699b210c0b054f4aff72ff7dcdf01512d" },
+        {
+          type: AccountKeyType.WeightedMultiSig,
+          threshold: 2,
+          keys: [
+            { weight: 1, key: "0x03e4a01407460c1c03ac0c82fd84f303a699b210c0b054f4aff72ff7dcdf01512d" },
+            { weight: 1, key: "0x0336f6355f5b532c3c1606f18fa2be7a16ae200c5159c8031dd25bfa389a4c9c06" },
+          ]
+        },
+        {
+          type: AccountKeyType.Public,
+          key: "0x02c8785266510368d9372badd4c7f4a94b692e82ba74e0b5e26b34558b0f081447"
+        },
+      ]
+    },
+    canonical: {
+      type: "0x05",
+      keys: [
+        "0x02a103e4a01407460c1c03ac0c82fd84f303a699b210c0b054f4aff72ff7dcdf01512d",
+        "0x04f84b02f848e301a103e4a01407460c1c03ac0c82fd84f303a699b210c0b054f4aff72ff7dcdf01512de301a10336f6355f5b532c3c1606f18fa2be7a16ae200c5159c8031dd25bfa389a4c9c06",
+        "0x02a102c8785266510368d9372badd4c7f4a94b692e82ba74e0b5e26b34558b0f081447",
+      ]
+    },
+    rlp: "0x05f898a302a103e4a01407460c1c03ac0c82fd84f303a699b210c0b054f4aff72ff7dcdf01512db84e04f84b02f848e301a103e4a01407460c1c03ac0c82fd84f303a699b210c0b054f4aff72ff7dcdf01512de301a10336f6355f5b532c3c1606f18fa2be7a16ae200c5159c8031dd25bfa389a4c9c06a302a102c8785266510368d9372badd4c7f4a94b692e82ba74e0b5e26b34558b0f081447",
+  }
+];
+
 describe("AccountKeyFactory", () => {
-  it("AccountKeyNil", () => {
-    const key = AccountKeyFactory.fromObject({ type: 0 });
-    assert.instanceOf(key, AccountKeyNil);
-    assert.equal(key.toRLP(), "0x80");
+  for (const tc of testcases) {
+    it(tc.clazz.name, () => {
+      const object = _.clone(tc.object);
+
+      const key = AccountKeyFactory.fromObject(object);
+      assert.instanceOf(key, tc.clazz);
+      assert.deepEqual(key.toObject(), tc.canonical);
+      assert.deepEqual(key.toRLP(), tc.rlp);
+      assert.deepEqual(parseAccountKey(key.toRLP()), tc.object);
+    });
+  }
+
+  it("AccountKeyWeightedMultiSig uncompressed public keys", () => {
+    // uncompressed public keys are automatically compressed
+    const key = AccountKeyFactory.fromObject({
+      type: 4,
+      threshold: 7,
+      keys: [
+        { weight: 1, key: "0x04c734b50ddb229be5e929fc4aa8080ae8240a802d23d3290e5e6156ce029b110e61a443ac3ffff164d1fb3617875f07641014cf17af6b7dc38e429fe838763712" },
+        { weight: 2, key: "0x0412d45f1cc56fbd6cd8fc877ab63b5092ac77db907a8a42c41dad3e98d7c64dfb8ef355a8d524eb444eba507f236309ce08370debaa136cb91b2f445774bff842" },
+        { weight: 3, key: "0x04ea9a9f85065a00d7b9ffd3a8532a574035984587fd08107d8f4cbad6b786b0cdb95ebb02d9397b4a8faceb58d485d612f0379a923ec0ddcf083378460a56acca" },
+        { weight: 4, key: "0x048551bc489d62fa2e6f767ba87fe93a62b679fca8ff3114eb5805e6487b51e8f64206aa84bc8955fcbfcc396854228aa63ebacd81b7311a31ab9d71d90b7ec3d7" },
+      ]});
+    assert.deepEqual(key.toObject(), {
+      type: "0x04",
+      threshold: "0x07",
+      keys: [
+        ["0x01", "0x02c734b50ddb229be5e929fc4aa8080ae8240a802d23d3290e5e6156ce029b110e"],
+        ["0x02", "0x0212d45f1cc56fbd6cd8fc877ab63b5092ac77db907a8a42c41dad3e98d7c64dfb"],
+        ["0x03", "0x02ea9a9f85065a00d7b9ffd3a8532a574035984587fd08107d8f4cbad6b786b0cd"],
+        ["0x04", "0x038551bc489d62fa2e6f767ba87fe93a62b679fca8ff3114eb5805e6487b51e8f6"]
+      ]
+    });
   });
 
-  it("AccountKeyLegacy", () => {
-    const key = AccountKeyFactory.fromObject({ type: 1 });
-    assert.instanceOf(key, AccountKeyLegacy);
-    assert.equal(key.toRLP(), "0x01c0");
-  });
-
-  it("AccountKeyPublic", () => {
-    const key = AccountKeyFactory.fromObject({ type: 2, key: "0x02dbac81e8486d68eac4e6ef9db617f7fbd79a04a3b323c982a09cdfc61f0ae0e8" });
-    assert.instanceOf(key, AccountKeyPublic);
-    assert.equal(key.getField("key"), "0x02dbac81e8486d68eac4e6ef9db617f7fbd79a04a3b323c982a09cdfc61f0ae0e8");
-    assert.equal(key.toRLP(), "0x02a102dbac81e8486d68eac4e6ef9db617f7fbd79a04a3b323c982a09cdfc61f0ae0e8");
-  });
-
-  it("AccountKeyFail", () => {
-    const key = AccountKeyFactory.fromObject({ type: 3 });
-    assert.instanceOf(key, AccountKeyFail);
-    assert.equal(key.toRLP(), "0x03c0");
-  });
-
-  it("AccountKeyWeightedMultiSig", () => {
-    const key = AccountKeyFactory.fromObject({ type: 4, threshold: 3, keys: [
-      [1, "0x04c734b50ddb229be5e929fc4aa8080ae8240a802d23d3290e5e6156ce029b110e61a443ac3ffff164d1fb3617875f07641014cf17af6b7dc38e429fe838763712"],
-      [1, "0x0412d45f1cc56fbd6cd8fc877ab63b5092ac77db907a8a42c41dad3e98d7c64dfb8ef355a8d524eb444eba507f236309ce08370debaa136cb91b2f445774bff842"],
-      [1, "0x04ea9a9f85065a00d7b9ffd3a8532a574035984587fd08107d8f4cbad6b786b0cdb95ebb02d9397b4a8faceb58d485d612f0379a923ec0ddcf083378460a56acca"],
-      [1, "0x048551bc489d62fa2e6f767ba87fe93a62b679fca8ff3114eb5805e6487b51e8f64206aa84bc8955fcbfcc396854228aa63ebacd81b7311a31ab9d71d90b7ec3d7"]
-    ]});
-    assert.instanceOf(key, AccountKeyWeightedMultiSig);
-    assert.equal(key.getField("threshold"), 3);
-    assert.equal(key.getField("keys").length, 4);
-    assert.equal(key.getField("keys")[0][0], 1);
-    assert.equal(key.getField("keys")[0][1], "0x02c734b50ddb229be5e929fc4aa8080ae8240a802d23d3290e5e6156ce029b110e");
-    assert.equal(key.toRLP(), "0x04f89303f890e301a102c734b50ddb229be5e929fc4aa8080ae8240a802d23d3290e5e6156ce029b110ee301a10212d45f1cc56fbd6cd8fc877ab63b5092ac77db907a8a42c41dad3e98d7c64dfbe301a102ea9a9f85065a00d7b9ffd3a8532a574035984587fd08107d8f4cbad6b786b0cde301a1038551bc489d62fa2e6f767ba87fe93a62b679fca8ff3114eb5805e6487b51e8f6");
-  });
-
-  it("AccountKeyRoleBased", () => {
-    const key1 = { type: 2, key: "0x03e4a01407460c1c03ac0c82fd84f303a699b210c0b054f4aff72ff7dcdf01512d" };
-    const key2 = { type: 4, threshold: 2, keys: [
-      [1, "0x03e4a01407460c1c03ac0c82fd84f303a699b210c0b054f4aff72ff7dcdf01512d"],
-      [1, "0x0336f6355f5b532c3c1606f18fa2be7a16ae200c5159c8031dd25bfa389a4c9c06"],
-    ]};
-    const key3 = { type: 2, key: "0x02c8785266510368d9372badd4c7f4a94b692e82ba74e0b5e26b34558b0f081447" };
-
-    const key1RLP = "0x02a103e4a01407460c1c03ac0c82fd84f303a699b210c0b054f4aff72ff7dcdf01512d";
-    const key2RLP = "0x04f84b02f848e301a103e4a01407460c1c03ac0c82fd84f303a699b210c0b054f4aff72ff7dcdf01512de301a10336f6355f5b532c3c1606f18fa2be7a16ae200c5159c8031dd25bfa389a4c9c06";
-    const key3RLP = "0x02a102c8785266510368d9372badd4c7f4a94b692e82ba74e0b5e26b34558b0f081447";
-
-    const key = AccountKeyFactory.fromObject({ type: 5, keys: [key1, key2, key3] });
-    assert.instanceOf(key, AccountKeyRoleBased);
-    assert.equal(key.getField("keys").length, 3);
-    assert.equal(key.getField("keys")[0], key1RLP);
-    assert.equal(key.getField("keys")[1], key2RLP);
-    assert.equal(key.getField("keys")[2], key3RLP);
-    assert.equal(key.toRLP(), "0x05f898a302a103e4a01407460c1c03ac0c82fd84f303a699b210c0b054f4aff72ff7dcdf01512db84e04f84b02f848e301a103e4a01407460c1c03ac0c82fd84f303a699b210c0b054f4aff72ff7dcdf01512de301a10336f6355f5b532c3c1606f18fa2be7a16ae200c5159c8031dd25bfa389a4c9c06a302a102c8785266510368d9372badd4c7f4a94b692e82ba74e0b5e26b34558b0f081447");
+  it("AccountKeyWeightedMultiSig array of tuples format", () => {
+    // mixed tuple and object formats
+    const key = AccountKeyFactory.fromObject({
+      type: 4,
+      threshold: 3,
+      keys: [
+        [1, "0x04c734b50ddb229be5e929fc4aa8080ae8240a802d23d3290e5e6156ce029b110e61a443ac3ffff164d1fb3617875f07641014cf17af6b7dc38e429fe838763712"],
+        [2, "0x0212d45f1cc56fbd6cd8fc877ab63b5092ac77db907a8a42c41dad3e98d7c64dfb"],
+        { weight: 3, key: "0x04ea9a9f85065a00d7b9ffd3a8532a574035984587fd08107d8f4cbad6b786b0cdb95ebb02d9397b4a8faceb58d485d612f0379a923ec0ddcf083378460a56acca" },
+        { weight: 4, key: "0x038551bc489d62fa2e6f767ba87fe93a62b679fca8ff3114eb5805e6487b51e8f6" },
+      ]});
+    assert.deepEqual(key.toObject(), {
+      type: "0x04",
+      threshold: "0x03",
+      keys: [
+        ["0x01", "0x02c734b50ddb229be5e929fc4aa8080ae8240a802d23d3290e5e6156ce029b110e"],
+        ["0x02", "0x0212d45f1cc56fbd6cd8fc877ab63b5092ac77db907a8a42c41dad3e98d7c64dfb"],
+        ["0x03", "0x02ea9a9f85065a00d7b9ffd3a8532a574035984587fd08107d8f4cbad6b786b0cd"],
+        ["0x04", "0x038551bc489d62fa2e6f767ba87fe93a62b679fca8ff3114eb5805e6487b51e8f6"]
+      ]
+    });
   });
 });

--- a/js-ext-core/test/accountkey.spec.ts
+++ b/js-ext-core/test/accountkey.spec.ts
@@ -1,7 +1,15 @@
 import { assert } from "chai";
+import { describe, it } from "mocha";
 
-import { AccountKeyFactory, AccountKeyFail, AccountKeyLegacy, AccountKeyNil, AccountKeyPublic, AccountKeyRoleBased, AccountKeyWeightedMultiSig } from "../src";
-
+import {
+  AccountKeyFactory,
+  AccountKeyNil,
+  AccountKeyLegacy,
+  AccountKeyPublic,
+  AccountKeyFail,
+  AccountKeyWeightedMultiSig,
+  AccountKeyRoleBased,
+} from "../src";
 
 describe("AccountKeyFactory", () => {
   it("AccountKeyNil", () => {

--- a/js-ext-core/test/tx.spec.ts
+++ b/js-ext-core/test/tx.spec.ts
@@ -1,6 +1,7 @@
 import { BigNumber } from "@ethersproject/bignumber";
 import { assert } from "chai";
 import _ from "lodash";
+import { describe, it } from "mocha";
 
 import {
   KlaytnTx,
@@ -25,7 +26,8 @@ import {
   TxTypeFeeDelegatedAccountUpdateWithRatio,
   TxTypeFeeDelegatedCancelWithRatio,
   isFeePayerSigTxType,
-  parseTransaction
+  parseTransaction,
+  ParsedTransaction,
 } from "../src";
 
 interface TestCase {
@@ -728,26 +730,91 @@ describe("KlaytnTxFactory", () => {
   });
 
   describe("parseTransaction", () => {
-    it("eth txtype", () => {
-      // let wallet = ethers.Wallet.createRandom();
-      // wallet.signTransaction({ to: wallet.address, value: 0x1234 });
-      const rlp = "0xf85f808080944f097405c6486cfd00d2daae9bec709590832eb3821234801ca0ba1fa1a6de839161a29db9f6733aab8d789eeb65ffa139b245d09e65398b75e3a00f46258a9f2f358041de590156396a9426f98d9a3bdbd22ed91c609b2359075d";
-      const obj = {
-        nonce: 0,
-        gasPrice: BigNumber.from(0),
-        gasLimit: BigNumber.from(0),
-        to: "0x4F097405C6486Cfd00d2dAae9bEC709590832eb3",
-        value: BigNumber.from(0x1234),
+    it("eth txtype 0", () => {
+      const rlp = "0xf8660f850ba43b740082520894c40b6909eb7085590e1c26cb3becc25368e249e980808207f5a0c5b24df459fb25cc688cd440d0ba768d930c56a2fe4913d7269e6cd1d404b7c7a06d4c94c64f534deb678e9e543f12a7f429df6d9ca24900c6df321dbe2d19c08f";
+      const obj: ParsedTransaction = {
+        hash: "0x7ab72ef9651ce0e76957a9abdc6fced3ff41979be7b544edcc033be236d5c28b",
+        to: "0xC40B6909EB7085590E1c26Cb3beCC25368e249E9",
+        from: "0x24e8eFD18D65bCb6b3Ba15a4698c0b0d69d13fF7",
+        nonce: 15,
+        gasLimit: "0x5208",
+        gasPrice: "0xba43b7400",
         data: "0x",
-        chainId: 0,
-        v: 28,
-        r: "0xba1fa1a6de839161a29db9f6733aab8d789eeb65ffa139b245d09e65398b75e3",
-        s: "0x0f46258a9f2f358041de590156396a9426f98d9a3bdbd22ed91c609b2359075d",
-        from: "0x4F097405C6486Cfd00d2dAae9bEC709590832eb3",
-        hash: "0xa0a675580c5ad468f51ba3029b2769a8fbaf6af6a97d802f49d3c8ab897d2372",
-        type: null
+        value: "0x0",
+        chainId: 1001,
+        v: 2037,
+        r: "0xc5b24df459fb25cc688cd440d0ba768d930c56a2fe4913d7269e6cd1d404b7c7",
+        s: "0x6d4c94c64f534deb678e9e543f12a7f429df6d9ca24900c6df321dbe2d19c08f",
+        type: null,
       };
       assert.deepEqual(parseTransaction(rlp), obj);
+    });
+    it("eth txtype 2", () => {
+      const rlp = "0x02f86d8203e9108459682f00850bfda3a30082520894c40b6909eb7085590e1c26cb3becc25368e249e98080c080a0f93a2e0d9959a14fc4e25ecffeea736ebad5cd0ce7d81ec2b138d81cc04258cda03410492583970bbbb8400416ff24b264bbdd21b873edbca762c329a7abdea1bd";
+      const obj: ParsedTransaction = {
+        hash: "0x4db90de769dc4f0ba1646b7ee966626f140b253d62ae59d64bafa38763c43b68",
+        to: "0xC40B6909EB7085590E1c26Cb3beCC25368e249E9",
+        from: "0x24e8eFD18D65bCb6b3Ba15a4698c0b0d69d13fF7",
+        nonce: 16,
+        gasLimit: "0x5208",
+        data: "0x",
+        value: "0x0",
+        chainId: 1001,
+        v: 0,
+        r: "0xf93a2e0d9959a14fc4e25ecffeea736ebad5cd0ce7d81ec2b138d81cc04258cd",
+        s: "0x3410492583970bbbb8400416ff24b264bbdd21b873edbca762c329a7abdea1bd",
+        type: 2,
+        accessList: [],
+        maxPriorityFeePerGas: "0x59682f00",
+        maxFeePerGas: "0xbfda3a300",
+      };
+      assert.deepEqual(parseTransaction(rlp), obj);
+    });
+    it("klay txtype FeeDelegatedSmartContractExecutionWithRatio", () => {
+      const rlp = "0x32f90105820311850ba43b7400830186a094cc18ec0261aadbe5fb5a7854449fc26b4f4286538094a2a8854b1802d8cd5de631e690817c253d6a9153a43fb5c1cb00000000000000000000000000000000000000000000000000000000000001231ef847f8458207f6a0febadbd36257942ae52cd03f1fd4159c1db0c407282d671ebf5074338561985ca042eef5fddc90bdbdbb6022884ac97c7fe8057717a33d3b3d98ca6c0d62bca41d94cb0eb737dfda52756495a5e08a9b37aab3b271daf847f8458207f6a06a37d31cfb23fcf3454a3a7a09f61336fac83c82efc4c466c1ac62e6d2a2a7e3a04871cff5a34fc3c3901ef98b86e8fbc43196ec18ebd0351466a3f5e51d2d7034";
+      const obj: ParsedTransaction = {
+        hash: "0xdce9d767b48ae92f11d9513572d6f9fc97720f72e11ea6829b7cd9cf5c5f2495",
+        to: "0xcc18eC0261AADbe5fB5a7854449FC26b4F428653",
+        from: "0xA2a8854b1802D8Cd5De631E690817c253d6a9153",
+        nonce: 785,
+        gasLimit: "0x186a0",
+        gasPrice: "0xba43b7400",
+        data: "0x3fb5c1cb0000000000000000000000000000000000000000000000000000000000000123",
+        value: "0x0",
+        type: 0x32,
+        feePayer: "0xCb0eb737dfda52756495A5e08A9b37AAB3b271dA",
+        txSignatures: [
+          ["0x07f6", "0xfebadbd36257942ae52cd03f1fd4159c1db0c407282d671ebf5074338561985c", "0x42eef5fddc90bdbdbb6022884ac97c7fe8057717a33d3b3d98ca6c0d62bca41d"]
+        ],
+        feePayerSignatures: [ // only in fee payer tx types
+          ["0x07f6", "0x6a37d31cfb23fcf3454a3a7a09f61336fac83c82efc4c466c1ac62e6d2a2a7e3", "0x4871cff5a34fc3c3901ef98b86e8fbc43196ec18ebd0351466a3f5e51d2d7034"]
+        ],
+        feeRatio: 30, // only in partial fee delegated tx types
+      };
+      assert.deepEqual(parseTransaction(rlp), obj);
+      // check that obj has all the necessary fields to construct a transaction
+      assert.equal(KlaytnTxFactory.fromRLP(rlp).txHashRLP(), rlp);
+    });
+    it("klay txtype AccountUpdate", () => {
+      const rlp = "0x20f88c56850ba43b740082cd1494e15cd70a41dfb05e7214004d7d054801b2a2f06ba302a103dc9dccbd788c00fa98f7f4082f2f714e799bc0c29d63f04d48b54fe6250453cdf847f8458207f5a0f33df326ed3e517a44f807a22dec8cc934f0957816759dde86665cd0cece4383a0694b19871c5485d513ed61c04d47d1c481010c706030d2733590c0944b496707";
+      const obj: ParsedTransaction = {
+        hash: "0x5121f718806349e42e5bead813bd0d15664e3a3437f844ae49c70be7bdbd1d0a",
+        // no 'to' field
+        from: "0xe15Cd70A41dfb05e7214004d7D054801b2a2f06b",
+        nonce: 86,
+        gasLimit: "0xcd14",
+        gasPrice: "0xba43b7400",
+        data: "0x", // no 'data' field, return '0x' instead
+        value: "0x0", // no 'value' field, return '0x0' instead
+        type: 0x20,
+        key: "0x02a103dc9dccbd788c00fa98f7f4082f2f714e799bc0c29d63f04d48b54fe6250453cd",
+        txSignatures: [
+          ["0x07f5", "0xf33df326ed3e517a44f807a22dec8cc934f0957816759dde86665cd0cece4383", "0x694b19871c5485d513ed61c04d47d1c481010c706030d2733590c0944b496707"],
+        ]
+      };
+      assert.deepEqual(parseTransaction(rlp), obj);
+      // check that obj has all the necessary fields to construct a transaction
+      assert.equal(KlaytnTxFactory.fromRLP(rlp).txHashRLP(), rlp);
     });
   });
 });

--- a/js-ext-core/test/util.spec.ts
+++ b/js-ext-core/test/util.spec.ts
@@ -58,6 +58,8 @@ describe("util", () => {
     assert.isTrue(isPartialFeeDelegationTxType(ty));
 
     assert.equal(parseTxType(), 0);
+    assert.equal(parseTxType(null), 0);
+    assert.equal(parseTxType(BigInt(1)), 1);
     assert.equal(parseTxType(0), 0);
     assert.equal(parseTxType(2), 2);
     assert.equal(parseTxType(8), 8);
@@ -67,6 +69,8 @@ describe("util", () => {
     assert.equal(parseTxType("SMART_CONTRACT_EXECUTION"), 0x30);
 
     assert.equal(getKaikasTxType(), 0);
+    assert.equal(getKaikasTxType(null), 0);
+    assert.equal(getKaikasTxType(BigInt(1)), 1);
     assert.equal(getKaikasTxType(0), 0);
     assert.equal(getKaikasTxType(2), 2);
     assert.equal(getKaikasTxType(8), "VALUE_TRANSFER");


### PR DESCRIPTION
- Add `parseAccountKey(rlp) -> object`

- AccountKeyWeightedMultiSig now accepts both representations:
	```js
	// array-of-objects: Recommended format
	{
      type: 4,
      threshold: 2,
      keys: [
        { weight: 1, key: "0x02c734b50ddb229be5e929fc4aa8080ae8240a802d23d3290e5e6156ce029b110e" },
        { weight: 1, key: "0x0212d45f1cc56fbd6cd8fc877ab63b5092ac77db907a8a42c41dad3e98d7c64dfb" },
      ]
    }
	```
	```js
	// array-of-tuples: Supported for backward compatibility
	{
      type: 4,
      threshold: 2,
      keys: [
        [1, "0x02c734b50ddb229be5e929fc4aa8080ae8240a802d23d3290e5e6156ce029b110e"],
        [1, "0x0212d45f1cc56fbd6cd8fc877ab63b5092ac77db907a8a42c41dad3e98d7c64dfb"],
      ]
    }
	```

- Fix `parseTransaction` to return numeric fields in proper format
	- not `0x` but `0x0`
	- not BigNumber but hex strings

- Fix `parseTxType` to accept bigint and null types
