### PR TITLE
ci: Run testing job whenever commits added to PR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
           registry-url: https://registry.npmjs.org/
 
       - name: Setup Python

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
           registry-url: https://registry.npmjs.org/
 
       - name: testing ethers-ext

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,8 +5,7 @@ on:
     branches:
       - main
   pull_request:
-    types:
-      - opened
+
 jobs:
   build:
     permissions: write-all
@@ -24,7 +23,7 @@ jobs:
       - name: testing ethers-ext
         shell: bash
         run: |
-          cd ethers-ext && npm install && npm run lint && npm run test && cd - 
+          cd ethers-ext && npm install && npm run lint && npm run test && cd -
 
       - name: testing js-ext-core
         shell: bash

--- a/ethers-ext/.eslintrc.js
+++ b/ethers-ext/.eslintrc.js
@@ -106,6 +106,6 @@ module.exports = {
   ],
   "ignorePatterns": [
     "example/browser-html/ethers-ext.bundle.js",
-    "example/browser-react/*",
+    "example/browser-react",
   ],
 };

--- a/ethers-ext/.eslintrc.js
+++ b/ethers-ext/.eslintrc.js
@@ -106,5 +106,6 @@ module.exports = {
   ],
   "ignorePatterns": [
     "example/browser-html/ethers-ext.bundle.js",
+    "example/browser-react/*",
   ],
 };

--- a/ethers-ext/package-lock.json
+++ b/ethers-ext/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@klaytn/ethers-ext",
-  "version": "0.9.9-beta",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@klaytn/ethers-ext",
-      "version": "0.9.9-beta",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@ethersproject/abstract-provider": "^5.7.0",


### PR DESCRIPTION
Make the `testing` job run when PR is opened, reopened, and commits added. (previously only when opened)

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows

> By default, a workflow only runs when a pull_request event's activity type is opened, synchronize, or reopened. 

https://github.com/orgs/community/discussions/24567

> if you push a new commit to the HEAD ref of a pull request then this “synchronize” event will be triggered. 