### PR TITLE
Patch accountKey.spec.ts

### DIFF
--- a/js-ext-core/test/accountkey.spec.ts
+++ b/js-ext-core/test/accountkey.spec.ts
@@ -118,6 +118,7 @@ describe("AccountKeyFactory", () => {
       const object = _.clone(tc.object);
 
       const key = AccountKeyFactory.fromObject(object);
+      // @ts-ignore
       assert.instanceOf(key, tc.clazz);
       assert.deepEqual(key.toObject(), tc.canonical);
       assert.deepEqual(key.toRLP(), tc.rlp);

--- a/js-ext-core/test/accountkey.spec.ts
+++ b/js-ext-core/test/accountkey.spec.ts
@@ -118,6 +118,7 @@ describe("AccountKeyFactory", () => {
       const object = _.clone(tc.object);
 
       const key = AccountKeyFactory.fromObject(object);
+      // In some typescript version, the following error “Cannot assign an abstract constructor type to a non-abstract constructor type.” occurs in the line below.
       // @ts-ignore
       assert.instanceOf(key, tc.clazz);
       assert.deepEqual(key.toObject(), tc.canonical);

--- a/js-ext-core/test/tx.spec.ts
+++ b/js-ext-core/test/tx.spec.ts
@@ -659,6 +659,8 @@ describe("KlaytnTxFactory", () => {
 
         // Object -> RLP
         const tx = KlaytnTxFactory.fromObject(object);
+        // In some typescript version, the following error “Cannot assign an abstract constructor type to a non-abstract constructor type.” occurs in the line below.
+        // @ts-ignore
         assert.instanceOf(tx, tc.clazz);
         assert.deepEqual(tx.toObject(), canonical);
         assert.equal(tx.sigRLP(), tc.sigRLP);
@@ -667,6 +669,8 @@ describe("KlaytnTxFactory", () => {
 
         // (signed) RLP -> Object
         const tx2 = KlaytnTxFactory.fromRLP(tc.senderTxHashRLP as string) as KlaytnTx;
+        // In some typescript version, the following error “Cannot assign an abstract constructor type to a non-abstract constructor type.” occurs in the line below.
+        // @ts-ignore
         assert.instanceOf(tx2, tc.clazz);
         assert.equal(tx2.senderTxHashRLP(), tx.senderTxHashRLP());
       });
@@ -680,6 +684,8 @@ describe("KlaytnTxFactory", () => {
 
         // Object -> RLP
         const tx = KlaytnTxFactory.fromObject(object);
+        // In some typescript version, the following error “Cannot assign an abstract constructor type to a non-abstract constructor type.” occurs in the line below.
+        // @ts-ignore
         assert.instanceOf(tx, tc.clazz);
         assert.deepEqual(tx.toObject(), canonical);
         assert.equal(tx.sigRLP(), tc.sigRLP);
@@ -691,6 +697,8 @@ describe("KlaytnTxFactory", () => {
 
         // (signed) RLP -> Object
         const tx2 = KlaytnTxFactory.fromRLP(tc.txHashRLP) as KlaytnTx;
+        // In some typescript version, the following error “Cannot assign an abstract constructor type to a non-abstract constructor type.” occurs in the line below.
+        // @ts-ignore
         assert.instanceOf(tx2, tc.clazz);
         assert.equal(tx2.txHashRLP(), tc.txHashRLP);
       });

--- a/js-ext-core/test/tx.spec.ts
+++ b/js-ext-core/test/tx.spec.ts
@@ -639,6 +639,8 @@ describe("KlaytnTxFactory", () => {
 
         // Object -> RLP
         const tx = KlaytnTxFactory.fromObject(object);
+        // In some typescript version, the following error “Cannot assign an abstract constructor type to a non-abstract constructor type.” occurs in the line below.
+        // @ts-ignore
         assert.instanceOf(tx, tc.clazz);
         assert.deepEqual(tx.toObject(), canonical);
         assert.equal(tx.sigRLP(), tc.sigRLP);


### PR DESCRIPTION
Because of typescript version, There is an error “Cannot assign an abstract constructor type to a non-abstract constructor type.”. 
So we ignore the line which occurs error. 